### PR TITLE
Add AddAuthentication method

### DIFF
--- a/did.go
+++ b/did.go
@@ -18,6 +18,7 @@ func (d DID) Empty() bool {
 }
 
 // Equals checks whether the DID is exactly equal to another DID
+// The check is case sensitive.
 func (d DID) Equals(other DID) bool {
 	return d.String() == other.String()
 }

--- a/document.go
+++ b/document.go
@@ -36,7 +36,7 @@ func (d *Document) AddAssertionMethod(v *VerificationMethod) {
 }
 
 // AddAuthenticationMethod adds a VerificationMethod as AuthenticationMethod
-// If the controller is not set, it will be set to the documents ID
+// If the controller is not set, it will be set to the document's ID
 func (d *Document) AddAuthenticationMethod(v *VerificationMethod) {
 	d.addVerificationMethodIfNotExists(v)
 	d.Authentication = append(d.Authentication, VerificationRelationship{
@@ -45,8 +45,10 @@ func (d *Document) AddAuthenticationMethod(v *VerificationMethod) {
 	})
 }
 
-// When adding verificationMethods, this metho makes sure there won't be any duplicates
-func (d *Document) addVerificationMethodIfNotExists(v*VerificationMethod) {
+// addVerificationMethodIfNotExists will add the verificationMethod to the document.
+// This method makes sure there won't be any duplicates based on pointer or ID.
+// If the controller of the verificationMethod is not set, the document's DID will be used.
+func (d *Document) addVerificationMethodIfNotExists(v *VerificationMethod) {
 	for _, ptr := range d.VerificationMethod {
 		// check if the pointer is already in the list
 		if ptr == v {

--- a/document.go
+++ b/document.go
@@ -26,16 +26,42 @@ type Document struct {
 }
 
 // Add a VerificationMethod as AssertionMethod
+// If the controller is not set, it will be set to the documents ID
 func (d *Document) AddAssertionMethod(v *VerificationMethod) {
-	if v.Controller.Empty() {
-		v.Controller = d.ID
-	}
-	d.VerificationMethod = append(d.VerificationMethod, v)
+	d.addVerificationMethodIfNotExists(v)
 	d.AssertionMethod = append(d.AssertionMethod, VerificationRelationship{
 		VerificationMethod: v,
 		reference:          v.ID,
 	})
+}
 
+// AddAuthenticationMethod adds a VerificationMethod as AuthenticationMethod
+// If the controller is not set, it will be set to the documents ID
+func (d *Document) AddAuthenticationMethod(v *VerificationMethod) {
+	d.addVerificationMethodIfNotExists(v)
+	d.Authentication = append(d.Authentication, VerificationRelationship{
+		VerificationMethod: v,
+		reference:          v.ID,
+	})
+}
+
+// When adding verificationMethods, this metho makes sure there won't be any duplicates
+func (d *Document) addVerificationMethodIfNotExists(v*VerificationMethod) {
+	for _, ptr := range d.VerificationMethod {
+		// check if the pointer is already in the list
+		if ptr == v {
+			return
+		}
+		// check if the actual ids match?
+		if ptr.ID.Equals(v.ID) {
+			return
+		}
+	}
+	// If the controller is not set, set the current document as controller
+	if v.Controller.Empty() {
+		v.Controller = d.ID
+	}
+	d.VerificationMethod = append(d.VerificationMethod, v)
 }
 
 func (d Document) MarshalJSON() ([]byte, error) {

--- a/document_test.go
+++ b/document_test.go
@@ -218,3 +218,41 @@ func TestService_UnmarshalServiceEndpoint(t *testing.T) {
 		assert.Equal(t, "foobar", target.Value)
 	})
 }
+
+func TestDocument_addVerificationMethodIfNotExists(t *testing.T) {
+	id, _ := ParseDID("did:example:123")
+	vmID, _ := ParseDID("did:example:123#key-1")
+	doc := Document{ID: *id}
+	vm := &VerificationMethod{ID: *vmID}
+	assert.Empty(t, doc.VerificationMethod,
+		"a new doc should not have any verificationMethods")
+
+	doc.addVerificationMethodIfNotExists(vm)
+	assert.Len(t, doc.VerificationMethod, 1,
+		"after adding, the doc should contain 1 verificationMethod")
+
+	assert.Equal(t, id.String(), doc.VerificationMethod[0].Controller.String(),
+		"the empty verificationMethod controller should be configured")
+
+	doc.addVerificationMethodIfNotExists(vm)
+	assert.Len(t, doc.VerificationMethod, 1,
+		"adding the same verificationRecord should should not result in a second entry")
+
+	assert.Equal(t, doc.VerificationMethod[0], vm,
+		"the pointers of the verificationMethod should match")
+
+	vm = &VerificationMethod{ID: *vmID}
+	doc.addVerificationMethodIfNotExists(vm)
+	assert.Len(t, doc.VerificationMethod, 1,
+		"adding a new verificationRecord with same ID should should not result in a second entry")
+
+	vmID, _ = ParseDID("did:example:123#key-2")
+	vm = &VerificationMethod{ID: *vmID}
+
+	doc.addVerificationMethodIfNotExists(vm)
+	assert.Len(t, doc.VerificationMethod, 2,
+		"adding a new verificationRecord with a different id should add an entry")
+
+	assert.Equal(t, doc.VerificationMethod[1], vm,
+		"the pointers of the new verificationMethod should match")
+}


### PR DESCRIPTION
What has changed:
* Easy adding of VerificationMethods as Authentication
* Prevent duplicate verificationMethods
* When adding, if the controller on a verificationMethod is not set, set it to the document ID.