### PR TITLE
Support VC types with a single value

### DIFF
--- a/vc/json.go
+++ b/vc/json.go
@@ -5,6 +5,7 @@ import (
 )
 
 const contextKey = "@context"
+const typeKey = "type"
 const credentialSubjectKey = "credentialSubject"
 const proofKey = "proof"
 

--- a/vc/vc.go
+++ b/vc/vc.go
@@ -83,13 +83,13 @@ func (vc VerifiableCredential) MarshalJSON() ([]byte, error) {
 	if data, err := json.Marshal(tmp); err != nil {
 		return nil, err
 	} else {
-		return marshal.NormalizeDocument(data, pluralContext, marshal.Unplural(credentialSubjectKey), marshal.Unplural(proofKey))
+		return marshal.NormalizeDocument(data, pluralContext, marshal.Unplural(typeKey), marshal.Unplural(credentialSubjectKey), marshal.Unplural(proofKey))
 	}
 }
 
 func (vc *VerifiableCredential) UnmarshalJSON(b []byte) error {
 	type Alias VerifiableCredential
-	normalizedVC, err := marshal.NormalizeDocument(b, pluralContext, marshal.Plural(credentialSubjectKey), marshal.Plural(proofKey))
+	normalizedVC, err := marshal.NormalizeDocument(b, pluralContext, marshal.Plural(typeKey), marshal.Plural(credentialSubjectKey), marshal.Plural(proofKey))
 	if err != nil {
 		return err
 	}

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -86,7 +86,7 @@ func TestVerifiableCredential_ContainsType(t *testing.T) {
 	input := VerifiableCredential{}
 	json.Unmarshal([]byte(`{
 		  "id":"did:example:123#vc-1",
-		  "type":["VerifiableCredential"]
+		  "type":"VerifiableCredential"
 		}`), &input)
 
 	t.Run("true", func(t *testing.T) {


### PR DESCRIPTION
See https://www.w3.org/TR/vc-data-model/#types

Found while testing `nuts-node` when issuing VCs, because its API states it requires the type as string, but when passed it's unmarshaled as VC which requires it to be a slice. The spec however states both are supported.