### PR TITLE
Support DIDURLs and stricter DID parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ doc := &did.Document{
 }
 
 // Add an assertionMethod
-keyID = *didID
-keyID.Fragment = "key-1"
+keyID, _ =: did.ParseDIDURL("did:example:123#key-1")
 
 keyPair, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 verificationMethod, err := did.NewVerificationMethod(*keyID, did.JsonWebKey2020, did.DID{}, keyPair.Public())

--- a/did/did.go
+++ b/did/did.go
@@ -2,6 +2,7 @@ package did
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/nuts-foundation/go-did"
 	"net/url"
@@ -74,12 +75,23 @@ func (d DID) URI() ssi.URI {
 	}
 }
 
-// ParseDID parses a raw DID. If it can't be parsed, an error is returned.
-func ParseDID(input string) (*DID, error) {
+func ParseDIDURL(input string) (*DID, error) {
 	ockDid, err := ockamDid.Parse(input)
 	if err != nil {
 		return nil, err
 	}
 
 	return &DID{DID: *ockDid}, nil
+}
+
+// ParseDID parses a raw DID. If it can't be parsed, an error is returned.
+func ParseDID(input string) (*DID, error) {
+	did, err := ParseDIDURL(input)
+	if err != nil {
+		return nil, err
+	}
+	if did.DID.IsURL() {
+		return nil, errors.New("invalid format: DID can not have path, fragment or query params")
+	}
+	return did, nil
 }

--- a/did/did.go
+++ b/did/did.go
@@ -75,6 +75,9 @@ func (d DID) URI() ssi.URI {
 	}
 }
 
+// ParseDIDURL parses a DID URL.
+// https://www.w3.org/TR/did-core/#did-url-syntax
+// A DID URL is a URL that builds on the DID scheme.
 func ParseDIDURL(input string) (*DID, error) {
 	ockDid, err := ockamDid.Parse(input)
 	if err != nil {
@@ -84,7 +87,9 @@ func ParseDIDURL(input string) (*DID, error) {
 	return &DID{DID: *ockDid}, nil
 }
 
-// ParseDID parses a raw DID. If it can't be parsed, an error is returned.
+// ParseDID parses a raw DID.
+// If the input contains a path, query or fragment, use the ParseDIDURL instead.
+// If it can't be parsed, an error is returned.
 func ParseDID(input string) (*DID, error) {
 	did, err := ParseDIDURL(input)
 	if err != nil {

--- a/did/did_test.go
+++ b/did/did_test.go
@@ -42,16 +42,57 @@ func TestDID_MarshalJSON(t *testing.T) {
 }
 
 func TestParseDID(t *testing.T) {
-	id, err := ParseDID("did:nuts:123")
+	t.Run("parse a DID", func(t *testing.T) {
+		id, err := ParseDID("did:nuts:123")
 
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-		return
-	}
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+			return
+		}
 
-	if id.String() != "did:nuts:123" {
-		t.Errorf("expected parsed did to be 'did:nuts:123', got: %s", id.String())
-	}
+		if id.String() != "did:nuts:123" {
+			t.Errorf("expected parsed did to be 'did:nuts:123', got: %s", id.String())
+		}
+	})
+	t.Run("error - invalid DID", func(t *testing.T) {
+		id, err := ParseDID("invalidDID")
+		assert.Nil(t, id)
+		assert.EqualError(t, err, "input does not begin with 'did:' prefix")
+
+	})
+	t.Run("error - DID URL", func(t *testing.T) {
+		id, err := ParseDID("did:nuts:123/path?query#fragment")
+		assert.Nil(t, id)
+		assert.EqualError(t, err, "invalid format: DID can not have path, fragment or query params")
+	})
+}
+
+func TestParseDIDURL(t *testing.T) {
+	t.Run("ok parse a DID", func(t *testing.T) {
+		id, err := ParseDIDURL("did:nuts:123")
+
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+			return
+		}
+
+		if id.String() != "did:nuts:123" {
+			t.Errorf("expected parsed did to be 'did:nuts:123', got: %s", id.String())
+		}
+	})
+
+	t.Run("ok - parse a DID URL", func(t *testing.T) {
+		id, err := ParseDIDURL("did:nuts:123/path?query#fragment")
+		assert.Equal(t, "did:nuts:123/path?query#fragment", id.String())
+		assert.NoError(t, err)
+	})
+
+	t.Run("error - invalid DID", func(t *testing.T) {
+		id, err := ParseDIDURL("invalidDID")
+		assert.Nil(t, id)
+		assert.EqualError(t, err, "input does not begin with 'did:' prefix")
+
+	})
 }
 
 func TestDID_String(t *testing.T) {
@@ -79,7 +120,7 @@ func TestDID_Empty(t *testing.T) {
 func TestDID_URI(t *testing.T) {
 	id, err := ParseDID("did:nuts:123")
 
-	if ! assert.NoError(t, err) {
+	if !assert.NoError(t, err) {
 		return
 	}
 

--- a/did/document_test.go
+++ b/did/document_test.go
@@ -16,7 +16,7 @@ import (
 
 func Test_Document(t *testing.T) {
 	id123, _ := ParseDID("did:example:123")
-	id123Method, _ := ParseDID("did:example:123#method")
+	id123Method, _ := ParseDIDURL("did:example:123#method")
 	id456, _ := ParseDID("did:example:456")
 
 
@@ -358,7 +358,7 @@ func TestRoundTripMarshalling(t *testing.T) {
 	// Test to check if a newly created VerificationMethod is the same as a parsed one.
 	t.Run("verification method marshalling", func(t *testing.T) {
 		id123, _ := ParseDID("did:example:123")
-		id123Method, _ := ParseDID("did:example:123#abc-method1")
+		id123Method, _ := ParseDIDURL("did:example:123#abc-method1")
 		pair, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		method, err := NewVerificationMethod(*id123Method, ssi.JsonWebKey2020, *id123, pair.PublicKey)
 		if !assert.NoError(t, err) {

--- a/did/validator.go
+++ b/did/validator.go
@@ -110,12 +110,12 @@ func (w baseValidator) Validate(document Document) error {
 		return makeValidationError(ErrInvalidContext)
 	}
 	// Verify `id`
-	if document.ID.Empty() {
+	if document.ID.Empty() || document.ID.IsURL() {
 		return makeValidationError(ErrInvalidID)
 	}
 	// Verify `controller`
 	for _, controller := range document.Controller {
-		if controller.Empty() {
+		if controller.Empty() || controller.IsURL() {
 			return makeValidationError(ErrInvalidController)
 		}
 	}

--- a/did/validator_test.go
+++ b/did/validator_test.go
@@ -15,19 +15,35 @@ func TestW3CSpecValidator(t *testing.T) {
 		assert.NoError(t, W3CSpecValidator{}.Validate(document()))
 	})
 	t.Run("base", func(t *testing.T) {
+		didUrl, err := ParseDIDURL("did:example:123#fragment")
+		if !assert.NoError(t, err) {
+			return
+		}
 		t.Run("context is missing DIDv1", func(t *testing.T) {
 			input := document()
 			input.Context = []ssi.URI{}
 			assertIsError(t, ErrInvalidContext, W3CSpecValidator{}.Validate(input))
 		})
-		t.Run("invalid ID", func(t *testing.T) {
+		t.Run("invalid ID - is empty", func(t *testing.T) {
 			input := document()
 			input.ID = DID{}
 			assertIsError(t, ErrInvalidID, W3CSpecValidator{}.Validate(input))
 		})
-		t.Run("invalid controller", func(t *testing.T) {
+		t.Run("invalid ID - is URL", func(t *testing.T) {
+			input := document()
+			input.ID = *didUrl
+			assertIsError(t, ErrInvalidID, W3CSpecValidator{}.Validate(input))
+		})
+
+		t.Run("invalid controller - is empty", func(t *testing.T) {
 			input := document()
 			input.Controller = append(input.Controller, DID{})
+			assertIsError(t, ErrInvalidController, W3CSpecValidator{}.Validate(input))
+		})
+
+		t.Run("invalid controller - is URL", func(t *testing.T) {
+			input := document()
+			input.Controller = append(input.Controller, *didUrl)
 			assertIsError(t, ErrInvalidController, W3CSpecValidator{}.Validate(input))
 		})
 	})

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/lestrrat-go/jwx v1.0.5
-	github.com/ockam-network/did v0.1.3
+	github.com/ockam-network/did v0.1.4-0.20210103172416-02ae01ce06d8
 	github.com/shengdoushi/base58 v1.0.0
 	github.com/stretchr/testify v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/lestrrat-go/jwx v1.0.5/go.mod h1:TPF17WiSFegZo+c20fdpw49QD+/7n4/IsGvE
 github.com/lestrrat-go/pdebug v0.0.0-20200204225717-4d6bd78da58d/go.mod h1:B06CSso/AWxiPejj+fheUINGeBKeeEZNt8w+EoU7+L8=
 github.com/ockam-network/did v0.1.3 h1:qJGdccOV4bLfsS/eFM+Aj+CdCRJKNMxbmJevQclw44k=
 github.com/ockam-network/did v0.1.3/go.mod h1:ZsbTIuVGt8OrQEbqWrSztUISN4joeMabdsinbLubbzw=
+github.com/ockam-network/did v0.1.4-0.20210103172416-02ae01ce06d8 h1:s5GFggECXv/KwF37ax4B7ACMOKoUnKvmur4i+7I07UE=
+github.com/ockam-network/did v0.1.4-0.20210103172416-02ae01ce06d8/go.mod h1:ZsbTIuVGt8OrQEbqWrSztUISN4joeMabdsinbLubbzw=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Fixes #38 
Note: This change breaks all calls to ParseDID() which are verificationMethods and services IDs