### PR TITLE
Let scalar types implement encoding.TextMarshaler to aid YAML encoding

### DIFF
--- a/did/did.go
+++ b/did/did.go
@@ -1,6 +1,7 @@
 package did
 
 import (
+	"encoding"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,9 @@ import (
 
 	ockamDid "github.com/ockam-network/did"
 )
+
+var _ fmt.Stringer = DID{}
+var _ encoding.TextMarshaler = DID{}
 
 const DIDContextV1 = "https://www.w3.org/ns/did/v1"
 
@@ -33,6 +37,11 @@ func (d DID) Empty() bool {
 // String returns the DID as formatted string.
 func (d DID) String() string {
 	return d.DID.String()
+}
+
+// MarshalText implements encoding.TextMarshaler
+func (d DID) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
 }
 
 // Equals checks whether the DID is exactly equal to another DID

--- a/did/did_test.go
+++ b/did/did_test.go
@@ -103,6 +103,14 @@ func TestDID_String(t *testing.T) {
 	assert.Equal(t, expected, fmt.Sprintf("%s", *id))
 }
 
+func TestDID_MarshalText(t *testing.T) {
+	expected := "did:nuts:123"
+	id, _ := ParseDID(expected)
+	actual, err := id.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(expected), actual)
+}
+
 func TestDID_Empty(t *testing.T) {
 	t.Run("not empty for filled did", func(t *testing.T) {
 		id, err := ParseDID("did:nuts:123")

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/lestrrat-go/iter v0.0.0-20200422075355-fc1769541911/go.mod h1:zIdgO1m
 github.com/lestrrat-go/jwx v1.0.5 h1:8bVUGXXkR3+YQNwuFof3lLxSJMLtrscHJfGI6ZIBRD0=
 github.com/lestrrat-go/jwx v1.0.5/go.mod h1:TPF17WiSFegZo+c20fdpw49QD+/7n4/IsGvEmCSWwT0=
 github.com/lestrrat-go/pdebug v0.0.0-20200204225717-4d6bd78da58d/go.mod h1:B06CSso/AWxiPejj+fheUINGeBKeeEZNt8w+EoU7+L8=
-github.com/ockam-network/did v0.1.3 h1:qJGdccOV4bLfsS/eFM+Aj+CdCRJKNMxbmJevQclw44k=
-github.com/ockam-network/did v0.1.3/go.mod h1:ZsbTIuVGt8OrQEbqWrSztUISN4joeMabdsinbLubbzw=
 github.com/ockam-network/did v0.1.4-0.20210103172416-02ae01ce06d8 h1:s5GFggECXv/KwF37ax4B7ACMOKoUnKvmur4i+7I07UE=
 github.com/ockam-network/did v0.1.4-0.20210103172416-02ae01ce06d8/go.mod h1:ZsbTIuVGt8OrQEbqWrSztUISN4joeMabdsinbLubbzw=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/types.go
+++ b/types.go
@@ -1,14 +1,25 @@
 package ssi
 
 import (
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"net/url"
 )
 
+var _ encoding.TextMarshaler = URI{}
+var _ json.Marshaler = URI{}
+var _ json.Unmarshaler = &URI{}
+var _ fmt.Stringer = URI{}
+
 // URI is a wrapper around url.URL to add json marshalling
 type URI struct {
 	url.URL
+}
+
+// MarshalText implements encoding.TextMarshaler
+func (v URI) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
 }
 
 func (v URI) MarshalJSON() ([]byte, error) {

--- a/types_test.go
+++ b/types_test.go
@@ -38,3 +38,9 @@ func TestParseURI(t *testing.T) {
 func TestURI_String(t *testing.T) {
 	assert.Equal(t, "http://test", URI{url.URL{Scheme: "http", Host: "test"}}.String())
 }
+
+func TestURI_MarshalText(t *testing.T) {
+	actual, err := URI{url.URL{Scheme: "http", Host: "test"}}.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("http://test"), actual)
+}


### PR DESCRIPTION
Go's YAML marshaler uses `encoding.TextMarshaler` to allow for hooking up "custom" marshaling. DIDs and URIs are now marshaled (to YAML) very ugly:

```
     did:
                    method: ""
                    id: ""
                    idstrings: []
                    params: []
                    path: ""
                    pathsegments: []
                    query: ""
                    fragment: ""
```

Implementing the interface fixes this.