### PR TITLE
Move VerificationMethods.Remove to DID Document

### DIFF
--- a/did/document.go
+++ b/did/document.go
@@ -43,21 +43,14 @@ func (vms VerificationMethods) FindByID(id DID) *VerificationMethod {
 }
 
 // remove a VerificationMethod from the slice.
-// It returns the removed verificationMethod or nil if it wasn't found
-func (vms *VerificationMethods) remove(id DID) *VerificationMethod {
-	var (
-		filteredVMS []*VerificationMethod
-		foundVM     *VerificationMethod
-	)
+func (vms *VerificationMethods) remove(id DID) {
+	var filteredVMS []*VerificationMethod
 	for _, vm := range *vms {
 		if !vm.ID.Equals(id) {
 			filteredVMS = append(filteredVMS, vm)
-		} else {
-			foundVM = vm
 		}
 	}
 	*vms = filteredVMS
-	return foundVM
 }
 
 // Add adds a verificationMethod to the verificationMethods if it not already present.
@@ -122,12 +115,12 @@ func (vmr *VerificationRelationships) Add(vm *VerificationMethod) {
 // RemoveVerificationMethod from the document if present.
 // It'll also remove all references to the VerificationMethod
 func (d *Document) RemoveVerificationMethod(vmId DID) {
-	_ = d.VerificationMethod.remove(vmId)
-	_ = d.AssertionMethod.Remove(vmId)
-	_ = d.Authentication.Remove(vmId)
-	_ = d.CapabilityDelegation.Remove(vmId)
-	_ = d.CapabilityInvocation.Remove(vmId)
-	_ = d.KeyAgreement.Remove(vmId)
+	d.VerificationMethod.remove(vmId)
+	d.AssertionMethod.Remove(vmId)
+	d.Authentication.Remove(vmId)
+	d.CapabilityDelegation.Remove(vmId)
+	d.CapabilityInvocation.Remove(vmId)
+	d.KeyAgreement.Remove(vmId)
 }
 
 // AddAuthenticationMethod adds a VerificationMethod as AuthenticationMethod

--- a/did/document.go
+++ b/did/document.go
@@ -42,9 +42,9 @@ func (vms VerificationMethods) FindByID(id DID) *VerificationMethod {
 	return nil
 }
 
-// Remove removes a VerificationMethod from the slice.
-// If a verificationMethod was removed with the given DID, it will be returned
-func (vms *VerificationMethods) Remove(id DID) *VerificationMethod {
+// remove a VerificationMethod from the slice.
+// If a verificationMethod was removed with the given URI it will be returned or nil otherwise
+func (vms *VerificationMethods) remove(id DID) *VerificationMethod {
 	var (
 		filteredVMS []*VerificationMethod
 		foundVM     *VerificationMethod
@@ -117,6 +117,17 @@ func (vmr *VerificationRelationships) Add(vm *VerificationMethod) {
 		}
 	}
 	*vmr = append(*vmr, VerificationRelationship{vm, vm.ID})
+}
+
+// RemoveVerificationMethod from the document if present.
+// It'll also remove all references to the VerificationMethod
+func (d *Document) RemoveVerificationMethod(vmId DID) {
+	_ = d.VerificationMethod.remove(vmId)
+	_ = d.AssertionMethod.Remove(vmId)
+	_ = d.Authentication.Remove(vmId)
+	_ = d.CapabilityDelegation.Remove(vmId)
+	_ = d.CapabilityInvocation.Remove(vmId)
+	_ = d.KeyAgreement.Remove(vmId)
 }
 
 // AddAuthenticationMethod adds a VerificationMethod as AuthenticationMethod

--- a/did/document.go
+++ b/did/document.go
@@ -43,7 +43,7 @@ func (vms VerificationMethods) FindByID(id DID) *VerificationMethod {
 }
 
 // remove a VerificationMethod from the slice.
-// If a verificationMethod was removed with the given URI it will be returned or nil otherwise
+// It returns the removed verificationMethod or nil if it wasn't found
 func (vms *VerificationMethods) remove(id DID) *VerificationMethod {
 	var (
 		filteredVMS []*VerificationMethod

--- a/did/document_test.go
+++ b/did/document_test.go
@@ -380,13 +380,22 @@ func TestDocument_RemoveVerificationMethod(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		doc := Document{}
-		doc.AddAssertionMethod(&VerificationMethod{ID: *id123})
+		vm := &VerificationMethod{ID: *id123}
+		doc.AddAssertionMethod(vm)
+		doc.AddAuthenticationMethod(vm)
+		doc.AddCapabilityDelegation(vm)
+		doc.AddCapabilityInvocation(vm)
+		doc.AddKeyAgreement(vm)
 
 		doc.RemoveVerificationMethod(*id123)
 
 		assert.Len(t, doc.VerificationMethod, 0,
 			"the verification method should have been deleted")
 		assert.Nil(t, doc.AssertionMethod.FindByID(*id123))
+		assert.Nil(t, doc.Authentication.FindByID(*id123))
+		assert.Nil(t, doc.CapabilityDelegation.FindByID(*id123))
+		assert.Nil(t, doc.CapabilityInvocation.FindByID(*id123))
+		assert.Nil(t, doc.KeyAgreement.FindByID(*id123))
 	})
 
 	t.Run("not found", func(t *testing.T) {

--- a/did/document_test.go
+++ b/did/document_test.go
@@ -19,7 +19,6 @@ func Test_Document(t *testing.T) {
 	id123Method, _ := ParseDIDURL("did:example:123#method")
 	id456, _ := ParseDID("did:example:456")
 
-
 	t.Run("it can marshal a json did into a Document", func(t *testing.T) {
 		jsonDoc := `
 {
@@ -376,6 +375,29 @@ func TestRoundTripMarshalling(t *testing.T) {
 	})
 }
 
+func TestDocument_RemoveVerificationMethod(t *testing.T) {
+	id123, _ := ParseDID("did:example:123")
+
+	t.Run("ok", func(t *testing.T) {
+		doc := Document{}
+		doc.AddAssertionMethod(&VerificationMethod{ID: *id123})
+
+		doc.RemoveVerificationMethod(*id123)
+
+		assert.Len(t, doc.VerificationMethod, 0,
+			"the verification method should have been deleted")
+		assert.Nil(t, doc.AssertionMethod.FindByID(*id123))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		doc := Document{}
+
+		doc.RemoveVerificationMethod(*id123)
+
+		assert.Len(t, doc.VerificationMethod, 0)
+	})
+}
+
 func TestVerificationRelationship_UnmarshalJSON(t *testing.T) {
 	t.Run("ok - unmarshal single did", func(t *testing.T) {
 		input := `"did:nuts:123#key-1"`
@@ -454,7 +476,7 @@ func Test_VerificationMethods(t *testing.T) {
 				&VerificationMethod{ID: *id123},
 				&VerificationMethod{ID: *id456},
 			}
-			removedVM := vms.Remove(*id456)
+			removedVM := vms.remove(*id456)
 			assert.Len(t, vms, 1,
 				"the verification method should have been deleted")
 			assert.Equal(t, *id456, removedVM.ID)
@@ -466,7 +488,7 @@ func Test_VerificationMethods(t *testing.T) {
 				&VerificationMethod{ID: *id123},
 				&VerificationMethod{ID: *id456},
 			}
-			removedVM := vms.Remove(*unknownID)
+			removedVM := vms.remove(*unknownID)
 			assert.Nil(t, removedVM)
 			assert.Len(t, vms, 2)
 		})
@@ -585,7 +607,6 @@ func TestVerificationRelationships(t *testing.T) {
 	})
 }
 
-
 func TestDocument_ResolveEndpointURL(t *testing.T) {
 	jsonDoc := `
 {
@@ -624,7 +645,7 @@ func TestDocument_ResolveEndpointURL(t *testing.T) {
 
 	t.Run("multiple services match", func(t *testing.T) {
 		jsonService :=
-`{
+			`{
 	"id":"did:example:123#linked-domain",
 	"type":"custom",
 	"serviceEndpoint": "https://example.com"

--- a/did/document_test.go
+++ b/did/document_test.go
@@ -485,10 +485,9 @@ func Test_VerificationMethods(t *testing.T) {
 				&VerificationMethod{ID: *id123},
 				&VerificationMethod{ID: *id456},
 			}
-			removedVM := vms.remove(*id456)
+			vms.remove(*id456)
 			assert.Len(t, vms, 1,
 				"the verification method should have been deleted")
-			assert.Equal(t, *id456, removedVM.ID)
 			assert.Equal(t, *id123, vms[0].ID)
 		})
 
@@ -497,8 +496,7 @@ func Test_VerificationMethods(t *testing.T) {
 				&VerificationMethod{ID: *id123},
 				&VerificationMethod{ID: *id456},
 			}
-			removedVM := vms.remove(*unknownID)
-			assert.Nil(t, removedVM)
+			vms.remove(*unknownID)
 			assert.Len(t, vms, 2)
 		})
 	})


### PR DESCRIPTION
closes #63

removing a verificationMethod on the document ensures removal from verificationRelations as well. 