### PR TITLE
add challenge to JsonWebSignature2020

### DIFF
--- a/vc/proof.go
+++ b/vc/proof.go
@@ -27,5 +27,6 @@ type Proof struct {
 // JSONWebSignature2020Proof is a VC proof with a signature according to JsonWebSignature2020
 type JSONWebSignature2020Proof struct {
 	Proof
-	Jws string `json:"jws"`
+	Challenge string `json:"challenge"`
+	Jws       string `json:"jws"`
 }


### PR DESCRIPTION
according to https://w3c-ccg.github.io/lds-jws2020/contexts/lds-jws2020-v1.json `challenge` is a property of JsonWebSignature2020. It's not contained by Proof.