### PR TITLE
newly added challenge must be optional or old proofs are invalid

### DIFF
--- a/vc/proof.go
+++ b/vc/proof.go
@@ -27,6 +27,6 @@ type Proof struct {
 // JSONWebSignature2020Proof is a VC proof with a signature according to JsonWebSignature2020
 type JSONWebSignature2020Proof struct {
 	Proof
-	Challenge string `json:"challenge"`
-	Jws       string `json:"jws"`
+	Challenge *string `json:"challenge"`
+	Jws       string  `json:"jws"`
 }

--- a/vc/proof.go
+++ b/vc/proof.go
@@ -27,6 +27,6 @@ type Proof struct {
 // JSONWebSignature2020Proof is a VC proof with a signature according to JsonWebSignature2020
 type JSONWebSignature2020Proof struct {
 	Proof
-	Challenge *string `json:"challenge"`
+	Challenge *string `json:"challenge,omitempty"`
 	Jws       string  `json:"jws"`
 }


### PR DESCRIPTION
for a v0.5.1