### PR TITLE
Remove unmaintained ockam/did library, can't support did:web

### DIFF
--- a/did/did.go
+++ b/did/did.go
@@ -15,7 +15,7 @@ import (
 var _ fmt.Stringer = DID{}
 var _ encoding.TextMarshaler = DID{}
 
-var didPattern = regexp.MustCompile(`^did:[a-z0-9]+:(?:[a-zA-Z0-9.\-_:]|%[0-9a-fA-F]{2})+(?:/.*|)(?:\?.*|)(?:#.*|)$`)
+var didPattern = regexp.MustCompile(`^did:([a-z0-9]+):((?:([a-zA-Z0-9.\-_:])+|(?:%[0-9a-fA-F]{2})+)+)(/.*|)(\?.*|)(#.*|)$`)
 
 // DIDContextV1 contains the JSON-LD context for a DID Document
 const DIDContextV1 = "https://www.w3.org/ns/did/v1"

--- a/did/did.go
+++ b/did/did.go
@@ -130,13 +130,17 @@ func ParseDIDURL(input string) (*DID, error) {
 		id = parsedURL.Opaque[:pathIdx]
 		path = parsedURL.Opaque[pathIdx+1:]
 	}
+	query := parsedURL.Query()
+	if len(query) == 0 {
+		query = nil
+	}
 
 	return &DID{
 		Method:   parsedURL.Scheme,
 		ID:       id,
 		Path:     path,
 		Fragment: parsedURL.Fragment,
-		Query:    parsedURL.Query(),
+		Query:    query,
 	}, nil
 }
 

--- a/did/did.go
+++ b/did/did.go
@@ -125,21 +125,20 @@ func ParseDIDURL(input string) (*DID, error) {
 		return nil, ErrInvalidDID
 	}
 
-	query, err := url.ParseQuery(strings.TrimPrefix(matches[4], "?"))
-	if err != nil {
-		return nil, ErrInvalidDID.wrap(err)
-	}
-	// Normalize empty query to nil for equality
-	if len(query) == 0 {
-		query = nil
-	}
-
 	result := DID{
 		Method:   matches[1],
 		ID:       matches[2],
 		Path:     strings.TrimPrefix(matches[3], "/"),
-		Query:    query,
 		Fragment: strings.TrimPrefix(matches[5], "#"),
+	}
+
+	query, err := url.ParseQuery(strings.TrimPrefix(matches[4], "?"))
+	if err != nil {
+		return nil, ErrInvalidDID.wrap(err)
+	}
+	if len(query) > 0 {
+		// Keep empty query as nil for equality checks
+		result.Query = query
 	}
 	return &result, nil
 }

--- a/did/did.go
+++ b/did/did.go
@@ -88,6 +88,21 @@ func (d DID) URI() ssi.URI {
 	}
 }
 
+// WithoutURL returns a copy of the DID without URL parts (fragment, query, path).
+func (d DID) WithoutURL() DID {
+	u := d.URL
+	u.Fragment = ""
+	u.RawFragment = ""
+	u.RawQuery = ""
+	u.Path = ""
+	u.RawPath = ""
+	return DID{
+		Method: d.Method,
+		ID:     d.ID,
+		URL:    u,
+	}
+}
+
 // ParseDIDURL parses a DID URL.
 // https://www.w3.org/TR/did-core/#did-url-syntax
 // A DID URL is a URL that builds on the DID scheme.

--- a/did/did.go
+++ b/did/did.go
@@ -24,10 +24,11 @@ func DIDContextV1URI() ssi.URI {
 
 // DID represent a Decentralized Identifier as specified by the DID Core specification (https://www.w3.org/TR/did-core/#identifier).
 type DID struct {
+	url.URL
 	Method string
 	ID     string
-	url.URL
-	Path string
+	Path   string
+	raw    string
 }
 
 // Empty checks whether the DID is set or not
@@ -37,7 +38,7 @@ func (d DID) Empty() bool {
 
 // String returns the DID as formatted string.
 func (d DID) String() string {
-	return "did:" + d.URL.String()
+	return d.raw
 }
 
 // MarshalText implements encoding.TextMarshaler
@@ -99,6 +100,7 @@ func (d DID) WithoutURL() DID {
 	return DID{
 		Method: d.Method,
 		ID:     d.ID,
+		raw:    "did:" + d.Method + ":" + d.ID,
 		URL:    u,
 	}
 }
@@ -131,6 +133,7 @@ func ParseDIDURL(input string) (*DID, error) {
 		Method: parsedURL.Scheme,
 		ID:     id,
 		Path:   path,
+		raw:    input,
 		URL:    *parsedURL,
 	}, nil
 }

--- a/did/did_test.go
+++ b/did/did_test.go
@@ -85,6 +85,17 @@ func TestParseDID(t *testing.T) {
 				assert.Equal(t, "web", id.Method)
 				assert.Equal(t, "example.com%3A3000:user:alice", id.ID)
 			})
+			t.Run("path, query and fragment", func(t *testing.T) {
+				id, err := ParseDIDURL("did:web:example.com%3A3000:user:alice/foo/bar?param=value#fragment")
+				require.NoError(t, err)
+				assert.Equal(t, "did:web:example.com%3A3000:user:alice/foo/bar?param=value#fragment", id.String())
+				assert.Equal(t, "web", id.Method)
+				assert.Equal(t, "example.com%3A3000:user:alice", id.ID)
+				assert.Equal(t, "foo/bar", id.Path)
+				assert.Len(t, id.Query(), 1)
+				assert.Equal(t, "value", id.Query().Get("param"))
+				assert.Equal(t, "fragment", id.Fragment)
+			})
 		})
 	})
 	t.Run("error - invalid DID", func(t *testing.T) {

--- a/did/did_test.go
+++ b/did/did_test.go
@@ -35,86 +35,18 @@ func TestDID_MarshalJSON(t *testing.T) {
 
 func TestParseDID(t *testing.T) {
 	t.Run("parse a DID", func(t *testing.T) {
-		t.Run("did:nuts", func(t *testing.T) {
-			id, err := ParseDID("did:nuts:123")
-			require.NoError(t, err)
-			assert.Equal(t, "did:nuts:123", id.String())
-			assert.Equal(t, "nuts", id.Method)
-			assert.Equal(t, "123", id.ID)
-		})
-		t.Run("fragment", func(t *testing.T) {
-			id, err := ParseDIDURL("did:example:123#fragment")
-			require.NoError(t, err)
-			assert.Equal(t, "did:example:123#fragment", id.String())
-			assert.Equal(t, "fragment", id.Fragment)
-		})
-		t.Run("path", func(t *testing.T) {
-			id, err := ParseDIDURL("did:example:123/subpath")
-			require.NoError(t, err)
-			assert.Equal(t, "123", id.ID)
-			assert.Equal(t, "subpath", id.Path)
-		})
-		t.Run("empty path", func(t *testing.T) {
-			id, err := ParseDIDURL("did:example:123/")
-			require.NoError(t, err)
-			assert.Equal(t, "123", id.ID)
-			assert.Equal(t, "", id.Path)
-		})
-		t.Run("path and query", func(t *testing.T) {
-			id, err := ParseDIDURL("did:example:123/subpath?param=value")
-			require.NoError(t, err)
-			assert.Equal(t, "123", id.ID)
-			assert.Equal(t, "subpath", id.Path)
-			assert.Len(t, id.Query, 1)
-			assert.Equal(t, "value", id.Query.Get("param"))
-		})
-		t.Run("did:web", func(t *testing.T) {
-			t.Run("root without port", func(t *testing.T) {
-				id, err := ParseDID("did:web:example.com")
-				require.NoError(t, err)
-				assert.Equal(t, "did:web:example.com", id.String())
-			})
-			t.Run("root with port", func(t *testing.T) {
-				id, err := ParseDID("did:web:example.com%3A3000")
-				require.NoError(t, err)
-				assert.Equal(t, "did:web:example.com%3A3000", id.String())
-			})
-			t.Run("subpath", func(t *testing.T) {
-				id, err := ParseDID("did:web:example.com%3A3000:user:alice")
-				require.NoError(t, err)
-				assert.Equal(t, "did:web:example.com%3A3000:user:alice", id.String())
-				assert.Equal(t, "web", id.Method)
-				assert.Equal(t, "example.com%3A3000:user:alice", id.ID)
-			})
-			t.Run("path, query and fragment", func(t *testing.T) {
-				id, err := ParseDIDURL("did:web:example.com%3A3000:user:alice/foo/bar?param=value#fragment")
-				require.NoError(t, err)
-				assert.Equal(t, "did:web:example.com%3A3000:user:alice/foo/bar?param=value#fragment", id.String())
-				assert.Equal(t, "web", id.Method)
-				assert.Equal(t, "example.com%3A3000:user:alice", id.ID)
-				assert.Equal(t, "foo/bar", id.Path)
-				assert.Len(t, id.Query, 1)
-				assert.Equal(t, "value", id.Query.Get("param"))
-				assert.Equal(t, "fragment", id.Fragment)
-			})
-		})
+		id, err := ParseDID("did:nuts:123")
+		require.NoError(t, err)
+		assert.Equal(t, "did:nuts:123", id.String())
+		assert.Equal(t, "nuts", id.Method)
+		assert.Equal(t, "123", id.ID)
 	})
 	t.Run("error - invalid DID", func(t *testing.T) {
 		id, err := ParseDID("invalidDID")
 		assert.Nil(t, id)
-		assert.EqualError(t, err, "invalid DID: input does not begin with 'did:' prefix")
+		assert.ErrorIs(t, err, ErrInvalidDID)
 	})
-	t.Run("error - no method", func(t *testing.T) {
-		id, err := ParseDID("did:")
-		assert.Nil(t, id)
-		assert.EqualError(t, err, "invalid DID")
-	})
-	t.Run("error - no method, but with path", func(t *testing.T) {
-		id, err := ParseDID("did:/foo")
-		assert.Nil(t, id)
-		assert.EqualError(t, err, "invalid DID")
-	})
-	t.Run("error - DID URL", func(t *testing.T) {
+	t.Run("error - input is a DID URL", func(t *testing.T) {
 		id, err := ParseDID("did:nuts:123/path?query#fragment")
 		assert.Nil(t, id)
 		assert.EqualError(t, err, "invalid DID: DID can not have path, fragment or query params")
@@ -128,23 +60,66 @@ func TestMustParseDID(t *testing.T) {
 }
 
 func TestParseDIDURL(t *testing.T) {
-	t.Run("ok parse a DID", func(t *testing.T) {
-		id, err := ParseDIDURL("did:nuts:123")
-
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-			return
-		}
-
-		if id.String() != "did:nuts:123" {
-			t.Errorf("expected parsed did to be 'did:nuts:123', got: %s", id.String())
-		}
-	})
-
-	t.Run("ok - parse a DID URL", func(t *testing.T) {
+	t.Run("parse a DID URL", func(t *testing.T) {
 		id, err := ParseDIDURL("did:nuts:123/path?query#fragment")
 		assert.Equal(t, "did:nuts:123/path?query=#fragment", id.String())
 		assert.NoError(t, err)
+	})
+	t.Run("with fragment", func(t *testing.T) {
+		id, err := ParseDIDURL("did:example:123#fragment")
+		require.NoError(t, err)
+		assert.Equal(t, "did:example:123#fragment", id.String())
+		assert.Equal(t, "fragment", id.Fragment)
+	})
+	t.Run("with path", func(t *testing.T) {
+		id, err := ParseDIDURL("did:example:123/subpath")
+		require.NoError(t, err)
+		assert.Equal(t, "123", id.ID)
+		assert.Equal(t, "subpath", id.Path)
+	})
+	t.Run("empty path", func(t *testing.T) {
+		id, err := ParseDIDURL("did:example:123/")
+		require.NoError(t, err)
+		assert.Equal(t, "123", id.ID)
+		assert.Equal(t, "", id.Path)
+	})
+	t.Run("path and query", func(t *testing.T) {
+		id, err := ParseDIDURL("did:example:123/subpath?param=value")
+		require.NoError(t, err)
+		assert.Equal(t, "123", id.ID)
+		assert.Equal(t, "subpath", id.Path)
+		assert.Len(t, id.Query, 1)
+		assert.Equal(t, "value", id.Query.Get("param"))
+	})
+	t.Run("did:web", func(t *testing.T) {
+		t.Run("root without port", func(t *testing.T) {
+			id, err := ParseDID("did:web:example.com")
+			require.NoError(t, err)
+			assert.Equal(t, "did:web:example.com", id.String())
+		})
+		t.Run("root with port", func(t *testing.T) {
+			id, err := ParseDID("did:web:example.com%3A3000")
+			require.NoError(t, err)
+			assert.Equal(t, "did:web:example.com%3A3000", id.String())
+		})
+		t.Run("subpath", func(t *testing.T) {
+			id, err := ParseDID("did:web:example.com%3A3000:user:alice")
+			require.NoError(t, err)
+			assert.Equal(t, "did:web:example.com%3A3000:user:alice", id.String())
+			assert.Equal(t, "web", id.Method)
+			assert.Equal(t, "example.com%3A3000:user:alice", id.ID)
+		})
+		t.Run("path, query and fragment", func(t *testing.T) {
+			id, err := ParseDIDURL("did:web:example.com%3A3000:user:alice/foo/bar?param=value#fragment")
+			require.NoError(t, err)
+			assert.Equal(t, "did:web:example.com%3A3000:user:alice/foo/bar?param=value#fragment", id.String())
+			assert.Equal(t, "web", id.Method)
+			assert.Equal(t, "example.com%3A3000:user:alice", id.ID)
+			assert.Equal(t, "foo/bar", id.Path)
+			assert.Len(t, id.Query, 1)
+			assert.Equal(t, "value", id.Query.Get("param"))
+			assert.Equal(t, "fragment", id.Fragment)
+		})
 	})
 
 	t.Run("ok - parsed DID URL equals constructed one", func(t *testing.T) {
@@ -173,11 +148,77 @@ func TestParseDIDURL(t *testing.T) {
 		assert.Equal(t, constructed, *parsed)
 	})
 
-	t.Run("error - invalid DID", func(t *testing.T) {
-		id, err := ParseDIDURL("invalidDID")
-		assert.Nil(t, id)
-		assert.EqualError(t, err, "invalid DID: input does not begin with 'did:' prefix")
+	t.Run("percent-encoded characters in ID are allowed", func(t *testing.T) {
+		parsed, err := ParseDIDURL("did:example:123%f8")
+		require.NoError(t, err)
+		constructed := DID{
+			Method: "example",
+			ID:     "123%f8",
+		}
+		assert.Equal(t, constructed, *parsed)
+	})
 
+	t.Run("format validation", func(t *testing.T) {
+		type testCase struct {
+			name string
+			did  string
+		}
+		t.Run("valid DIDs", func(t *testing.T) {
+			testCases := []testCase{
+				{name: "basic DID", did: "did:example:123"},
+				{name: "with query", did: "did:example:123?foo=bar"},
+				{name: "with fragment", did: "did:example:123#foo"},
+				{name: "with path", did: "did:example:123/foo"},
+				{name: "with query, fragment and path", did: "did:example:123/foo?key=value#fragment"},
+				{name: "with semicolons", did: "did:example:123/foo?key=value#fragment"},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					id, err := ParseDIDURL(tc.did)
+					assert.NoError(t, err, "expected no error for DID: "+tc.did)
+					assert.Equal(t, tc.did, id.String())
+				})
+			}
+		})
+		t.Run("invalid DIDs", func(t *testing.T) {
+			testCases := []testCase{
+				{
+					name: "no method",
+					did:  "did:",
+				},
+				{
+					name: "does not begin with 'did:' prefix",
+					did:  "example:123",
+				},
+				{
+					name: "method contains invalid character",
+					did:  "did:example_:1234",
+				},
+				{
+					name: "ID is empty",
+					did:  "did:example:",
+				},
+				{
+					name: "ID is empty, with path",
+					did:  "did:example:/path",
+				},
+				{
+					name: "ID is empty, with fragment",
+					did:  "did:example:#fragment",
+				},
+				{
+					name: "ID contains invalid chars",
+					did:  "did:example:te@st",
+				},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					id, err := ParseDIDURL(tc.did)
+					assert.Error(t, err, "expected an error for DID: "+tc.did)
+					assert.Nil(t, id)
+				})
+			}
+		})
 	})
 }
 
@@ -199,6 +240,48 @@ func TestDID_MarshalText(t *testing.T) {
 	actual, err := id.MarshalText()
 	assert.NoError(t, err)
 	assert.Equal(t, []byte(expected), actual)
+}
+
+func TestDID_Equal(t *testing.T) {
+	t.Run("DID", func(t *testing.T) {
+		t.Run("equal", func(t *testing.T) {
+			assert.True(t, MustParseDID("did:example:123").Equals(MustParseDID("did:example:123")))
+		})
+		t.Run("method differs", func(t *testing.T) {
+			assert.False(t, MustParseDID("did:example1:123").Equals(MustParseDID("did:example:123")))
+		})
+		t.Run("ID differs", func(t *testing.T) {
+			assert.False(t, MustParseDID("did:example:1234").Equals(MustParseDID("did:example:123")))
+		})
+		t.Run("one DID is empty", func(t *testing.T) {
+			assert.False(t, MustParseDID("did:example:1234").Equals(DID{}))
+		})
+		t.Run("both DIDs are empty", func(t *testing.T) {
+			assert.True(t, DID{}.Equals(DID{}))
+		})
+	})
+	t.Run("DID URL", func(t *testing.T) {
+		t.Run("equal", func(t *testing.T) {
+			d1 := MustParseDIDURL("did:example:123/foo?key=value#fragment")
+			d2 := MustParseDIDURL("did:example:123/foo?key=value#fragment")
+			assert.True(t, d1.Equals(d2))
+		})
+		t.Run("fragment differs", func(t *testing.T) {
+			d1 := MustParseDIDURL("did:example:123/foo?key=value")
+			d2 := MustParseDIDURL("did:example:123/foo?key=value#fragment")
+			assert.False(t, d1.Equals(d2))
+		})
+		t.Run("query in different order", func(t *testing.T) {
+			d1 := MustParseDIDURL("did:example:123/foo?k1=a&k2=b")
+			d2 := MustParseDIDURL("did:example:123/foo?k2=b&k1=a")
+			assert.True(t, d1.Equals(d2))
+		})
+		t.Run("path differs", func(t *testing.T) {
+			d1 := MustParseDIDURL("did:example:123/fuzz?key=value#fragment")
+			d2 := MustParseDIDURL("did:example:123/fizz?key=value#fragment")
+			assert.False(t, d1.Equals(d2))
+		})
+	})
 }
 
 func TestDID_Empty(t *testing.T) {

--- a/did/did_test.go
+++ b/did/did_test.go
@@ -103,6 +103,16 @@ func TestParseDID(t *testing.T) {
 		assert.Nil(t, id)
 		assert.EqualError(t, err, "invalid DID: input does not begin with 'did:' prefix")
 	})
+	t.Run("error - no method", func(t *testing.T) {
+		id, err := ParseDID("did:")
+		assert.Nil(t, id)
+		assert.EqualError(t, err, "invalid DID")
+	})
+	t.Run("error - no method, but with path", func(t *testing.T) {
+		id, err := ParseDID("did:/foo")
+		assert.Nil(t, id)
+		assert.EqualError(t, err, "invalid DID")
+	})
 	t.Run("error - DID URL", func(t *testing.T) {
 		id, err := ParseDID("did:nuts:123/path?query#fragment")
 		assert.Nil(t, id)

--- a/did/did_test.go
+++ b/did/did_test.go
@@ -3,7 +3,6 @@ package did
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"github.com/stretchr/testify/require"
 	"io"
 	"net/url"
@@ -228,12 +227,6 @@ func TestMustParseDIDURL(t *testing.T) {
 	})
 }
 
-func TestDID_String(t *testing.T) {
-	expected := "did:nuts:123"
-	id, _ := ParseDID(expected)
-	assert.Equal(t, expected, fmt.Sprintf("%s", *id))
-}
-
 func TestDID_MarshalText(t *testing.T) {
 	expected := "did:nuts:123"
 	id, _ := ParseDID(expected)
@@ -282,6 +275,68 @@ func TestDID_Equal(t *testing.T) {
 			assert.False(t, d1.Equals(d2))
 		})
 	})
+}
+
+func TestDID_String(t *testing.T) {
+	type testCase struct {
+		name     string
+		expected string
+		did      DID
+	}
+	testCases := []testCase{
+		{
+			name:     "basic DID",
+			expected: "did:example:123",
+			did: DID{
+				Method: "example",
+				ID:     "123",
+			},
+		},
+		{
+			name:     "with path",
+			expected: "did:example:123/foo",
+			did: DID{
+				Method: "example",
+				ID:     "123",
+				Path:   "foo",
+			},
+		},
+		{
+			name:     "with fragment",
+			expected: "did:example:123#fragment",
+			did: DID{
+				Method:   "example",
+				ID:       "123",
+				Fragment: "fragment",
+			},
+		},
+		{
+			name:     "with query",
+			expected: "did:example:123?key=value",
+			did: DID{
+				Method: "example",
+				ID:     "123",
+				Query:  url.Values{"key": []string{"value"}},
+			},
+		},
+		{
+			name:     "with everything",
+			expected: "did:example:123/foo?key=value#fragment",
+			did: DID{
+				Method:   "example",
+				ID:       "123",
+				Path:     "foo",
+				Fragment: "fragment",
+				Query:    url.Values{"key": []string{"value"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.did.String())
+		})
+	}
 }
 
 func TestDID_Empty(t *testing.T) {

--- a/did/did_test.go
+++ b/did/did_test.go
@@ -108,6 +108,13 @@ func TestParseDIDURL(t *testing.T) {
 			assert.Equal(t, "web", id.Method)
 			assert.Equal(t, "example.com%3A3000:user:alice", id.ID)
 		})
+		t.Run("subpath without port", func(t *testing.T) {
+			id, err := ParseDID("did:web:example.com:u:5")
+			require.NoError(t, err)
+			assert.Equal(t, "did:web:example.com:u:5", id.String())
+			assert.Equal(t, "web", id.Method)
+			assert.Equal(t, "example.com:u:5", id.ID)
+		})
 		t.Run("path, query and fragment", func(t *testing.T) {
 			id, err := ParseDIDURL("did:web:example.com%3A3000:user:alice/foo/bar?param=value#fragment")
 			require.NoError(t, err)

--- a/did/did_test.go
+++ b/did/did_test.go
@@ -208,3 +208,11 @@ func TestError(t *testing.T) {
 	assert.True(t, errors.Is(actual, io.EOF))
 	assert.False(t, errors.Is(actual, io.ErrShortBuffer))
 }
+
+func TestDID_WithoutURL(t *testing.T) {
+	id := MustParseDIDURL("did:example:123/path?key=value#fragment").WithoutURL()
+	assert.Equal(t, "did:example:123", id.String())
+	assert.Empty(t, id.Path)
+	assert.Empty(t, id.Fragment)
+	assert.Empty(t, id.Query())
+}

--- a/did/did_test.go
+++ b/did/did_test.go
@@ -64,8 +64,8 @@ func TestParseDID(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, "123", id.ID)
 			assert.Equal(t, "subpath", id.Path)
-			assert.Len(t, id.Query(), 1)
-			assert.Equal(t, "value", id.Query().Get("param"))
+			assert.Len(t, id.Query, 1)
+			assert.Equal(t, "value", id.Query.Get("param"))
 		})
 		t.Run("did:web", func(t *testing.T) {
 			t.Run("root without port", func(t *testing.T) {
@@ -92,8 +92,8 @@ func TestParseDID(t *testing.T) {
 				assert.Equal(t, "web", id.Method)
 				assert.Equal(t, "example.com%3A3000:user:alice", id.ID)
 				assert.Equal(t, "foo/bar", id.Path)
-				assert.Len(t, id.Query(), 1)
-				assert.Equal(t, "value", id.Query().Get("param"))
+				assert.Len(t, id.Query, 1)
+				assert.Equal(t, "value", id.Query.Get("param"))
 				assert.Equal(t, "fragment", id.Fragment)
 			})
 		})
@@ -142,7 +142,7 @@ func TestParseDIDURL(t *testing.T) {
 
 	t.Run("ok - parse a DID URL", func(t *testing.T) {
 		id, err := ParseDIDURL("did:nuts:123/path?query#fragment")
-		assert.Equal(t, "did:nuts:123/path?query#fragment", id.String())
+		assert.Equal(t, "did:nuts:123/path?query=#fragment", id.String())
 		assert.NoError(t, err)
 	})
 
@@ -214,5 +214,5 @@ func TestDID_WithoutURL(t *testing.T) {
 	assert.Equal(t, "did:example:123", id.String())
 	assert.Empty(t, id.Path)
 	assert.Empty(t, id.Fragment)
-	assert.Empty(t, id.Query())
+	assert.Empty(t, id.Query)
 }

--- a/did/did_test.go
+++ b/did/did_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/require"
 	"io"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -144,6 +145,32 @@ func TestParseDIDURL(t *testing.T) {
 		id, err := ParseDIDURL("did:nuts:123/path?query#fragment")
 		assert.Equal(t, "did:nuts:123/path?query=#fragment", id.String())
 		assert.NoError(t, err)
+	})
+
+	t.Run("ok - parsed DID URL equals constructed one", func(t *testing.T) {
+		parsed, err := ParseDIDURL("did:nuts:123/path?key=value#fragment")
+		require.NoError(t, err)
+		constructed := DID{
+			Method: "nuts",
+			ID:     "123",
+			Path:   "path",
+			Query: url.Values{
+				"key": []string{"value"},
+			},
+			Fragment: "fragment",
+		}
+		assert.Equal(t, constructed, *parsed)
+	})
+	t.Run("ok - parsed DID URL equals constructed one (no query)", func(t *testing.T) {
+		parsed, err := ParseDIDURL("did:nuts:123/path#fragment")
+		require.NoError(t, err)
+		constructed := DID{
+			Method:   "nuts",
+			ID:       "123",
+			Path:     "path",
+			Fragment: "fragment",
+		}
+		assert.Equal(t, constructed, *parsed)
 	})
 
 	t.Run("error - invalid DID", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	github.com/lestrrat-go/jwx v1.2.26
-	github.com/nuts-foundation/did-ockam v0.0.0-20230313074753-fafd938c948c
 	github.com/shengdoushi/base58 v1.0.0
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/lestrrat-go/jwx v1.2.26/go.mod h1:MaiCdGbn3/cckbOFSCluJlJMmp9dmZm5hDu
 github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNBEYU=
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
-github.com/nuts-foundation/did-ockam v0.0.0-20230313074753-fafd938c948c h1:Q2NawUYqQ13HUI1TM6ulcLtsxnwxPMDWsSWjyFWTTLU=
-github.com/nuts-foundation/did-ockam v0.0.0-20230313074753-fafd938c948c/go.mod h1:n0NQI71qGVVShnPDjYdCoNStEW0zZoVWbeSQ+esXuhs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Replaced with simple URL parsing.
If we want to support did:web we either need to update the library to support percent-encoded DID IDs, or replace it. Seeing the library, I figured replacing is in the long run more easier; one less dependency and less complicated code.