### PR TITLE
Add alsoKnownAs property to DID document

### DIFF
--- a/did/document.go
+++ b/did/document.go
@@ -20,6 +20,7 @@ type Document struct {
 	Context              []ssi.URI                 `json:"@context"`
 	ID                   DID                       `json:"id"`
 	Controller           []DID                     `json:"controller,omitempty"`
+	AlsoKnownAs          []ssi.URI                 `json:"alsoKnownAs,omitempty"`
 	VerificationMethod   VerificationMethods       `json:"verificationMethod,omitempty"`
 	Authentication       VerificationRelationships `json:"authentication,omitempty"`
 	AssertionMethod      VerificationRelationships `json:"assertionMethod,omitempty"`

--- a/did/document_test.go
+++ b/did/document_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	ssi "github.com/nuts-foundation/go-did"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,17 +25,17 @@ func Test_Document(t *testing.T) {
 {
 	"@context": ["https://www.w3.org/ns/did/v1"],
 	"id": "did:web:identity.foundation",
-	"Controller": ["did:nuts:123", "did:web:example.org"]
+	"controller": ["did:nuts:123", "did:web:example.com"],
+	"alsoKnownAs": ["did:web:example.com"]
 }`
 		doc := Document{}
 		err := json.Unmarshal([]byte(jsonDoc), &doc)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-			return
-		}
-		if doc.Controller[0].String() != "did:nuts:123" {
-			t.Errorf("expected 'did:nuts:123', got: %s", doc.Controller[0].String())
-		}
+
+		require.NoError(t, err)
+		assert.Equal(t, "did:web:identity.foundation", doc.ID.String())
+		assert.Equal(t, "did:nuts:123", doc.Controller[0].String())
+		assert.Equal(t, "did:web:example.com", doc.Controller[1].String())
+		assert.Equal(t, "did:web:example.com", doc.AlsoKnownAs[0].String())
 	})
 
 	var actual Document

--- a/did/test/did1-expected.json
+++ b/did/test/did1-expected.json
@@ -5,6 +5,9 @@
     "did:nuts:04cf1e20-378a-4e38-ab1b-401a5018c9ff",
     "did:nuts:f03a00f1-9615-4060-bd00-bd282e150c46"
   ],
+  "alsoKnownAs": [
+    "did:web:example.com"
+  ],
   "verificationMethod": [
     {
       "id": "did:nuts:04cf1e20-378a-4e38-ab1b-401a5018c9ff#key-1",

--- a/did/test/did1.json
+++ b/did/test/did1.json
@@ -7,6 +7,9 @@
     "did:nuts:04cf1e20-378a-4e38-ab1b-401a5018c9ff",
     "did:nuts:f03a00f1-9615-4060-bd00-bd282e150c46"
   ],
+  "alsoKnownAs": [
+    "did:web:example.com"
+  ],
   "verificationMethod": [
     {
       "id": "did:nuts:04cf1e20-378a-4e38-ab1b-401a5018c9ff#key-1",


### PR DESCRIPTION
Specified by https://www.w3.org/TR/did-core/#also-known-as

We probably want to for out derived did:web documents, referring to did:nuts.