### PR TITLE
Support VCs and VPs in JWT format

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,19 @@
 
 A library to parse and generate W3C [DID Documents](https://www.w3.org/TR/did-core/) and W3C [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/).
 
-## Example usage:
+## Example usage
+
+### Parsing a DID document
+```go
+didDoc := did.Document{}
+err := json.Unmarshal([]byte(didDocJson), &didDoc)
+if err != nil {
+    panic(err)
+}
+// do something with didDoc
+````
+
+### Creating a DID document
 Creation of a simple DID Document which is its own controller and contains an AssertionMethod.
 ```go
 didID, err := did.ParseDID("did:example:123")
@@ -29,18 +41,8 @@ doc.AddAssertionMethod(verificationMethod)
 
 didJson, _ := json.MarshalIndent(doc, "", "  ")
 fmt.Println(string(didJson))
-
-// Unmarshalling of a json did document:
-parsedDIDDoc := did.Document{}
-err = json.Unmarshal(didJson, &parsedDIDDoc)
-
-// It can return the key in the convenient lestrrat-go/jwx JWK
-parsedDIDDoc.AssertionMethod[0].JWK()
-
-// Or return a native crypto.PublicKey
-parsedDIDDoc.AssertionMethod[0].PublicKey()
-
 ```
+
 Outputs:
 ```json
 {
@@ -64,8 +66,11 @@ Outputs:
     }
   ]
 }
-
 ```
+
+### Parsing Verifiable Credentials and Verifiable Presentations
+The library supports parsing of Verifiable Credentials and Verifiable Presentations in JSON-LD, and JWT proof format.
+Use `ParseVerifiableCredential(raw string)` and `ParseVerifiablePresentation(raw string)` for both.
 
 ## Installation
 ```
@@ -73,5 +78,4 @@ go get github.com/nuts-foundation/go-did
 ```
 
 ## State of the library
-Currently, the library is under development. The api can change without notice.
-Checkout the issues and PRs to be informed about any development.
+We keep the API stable, breaking changes will only be introduced in new major versions.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
 A library to parse and generate W3C [DID Documents](https://www.w3.org/TR/did-core/) and W3C [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/).
 
 ## Example usage
+Note on parsing: in earlier versions, DID documents, credentials and presentations were parsed using `UnmarshalJSON`.
+Now, `ParseDocument()`, `ParseVerifiableCredential()` and `ParseVerifiablePresentation()` should be used instead: they better support VCs and VPs in JWT format.
 
 ### Parsing a DID document
 ```go
-didDoc := did.Document{}
-err := json.Unmarshal([]byte(didDocJson), &didDoc)
+didDoc, err := did.ParseDocument(didDocJson)
 if err != nil {
     panic(err)
 }
@@ -70,7 +71,7 @@ Outputs:
 
 ### Parsing Verifiable Credentials and Verifiable Presentations
 The library supports parsing of Verifiable Credentials and Verifiable Presentations in JSON-LD, and JWT proof format.
-Use `ParseVerifiableCredential(raw string)` and `ParseVerifiablePresentation(raw string)` for both.
+Use `ParseVerifiableCredential(raw string)` and `ParseVerifiablePresentation(raw string)`.
 
 ## Installation
 ```

--- a/did/document_test.go
+++ b/did/document_test.go
@@ -341,8 +341,7 @@ func TestRoundTripMarshalling(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase, func(t *testing.T) {
-			document := Document{}
-			err := json.Unmarshal(test.ReadTestFile("test/"+testCase+".json"), &document)
+			document, err := ParseDocument(string(test.ReadTestFile("test/" + testCase + ".json")))
 			if !assert.NoError(t, err) {
 				return
 			}

--- a/vc/vc.go
+++ b/vc/vc.go
@@ -45,6 +45,7 @@ var errCredentialSubjectWithoutID = errors.New("credential subjects have no ID")
 
 // ParseVerifiableCredential parses a Verifiable Credential from a string, which can be either in JSON-LD or JWT format.
 // If the format is JWT, the parsed token can be retrieved using JWT().
+// Note that it does not do any signature checking.
 func ParseVerifiableCredential(raw string) (*VerifiableCredential, error) {
 	raw = strings.TrimSpace(raw)
 	if strings.HasPrefix(raw, "{") {

--- a/vc/vc.go
+++ b/vc/vc.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/lestrrat-go/jwx/jwt"
 	"github.com/nuts-foundation/go-did/did"
+	"strings"
 	"time"
 
 	ssi "github.com/nuts-foundation/go-did"
@@ -32,6 +34,94 @@ func VCContextV1URI() ssi.URI {
 	}
 }
 
+const (
+	// JSONLDCredentialProofFormat is the format for JSON-LD based credentials.
+	JSONLDCredentialProofFormat string = "ldp_vc"
+	// JWTCredentialsProofFormat is the format for JWT based credentials.
+	JWTCredentialsProofFormat = "jwt_vc"
+)
+
+var errCredentialSubjectWithoutID = errors.New("credential subjects have no ID")
+
+// ParseVerifiableCredential parses a Verifiable Credential from a string, which can be either in JSON-LD or JWT format.
+// If the format is JWT, the parsed token can be retrieved using JWT().
+func ParseVerifiableCredential(raw string) (*VerifiableCredential, error) {
+	raw = strings.TrimSpace(raw)
+	if strings.HasPrefix(raw, "{") {
+		// Assume JSON-LD format
+		type Alias VerifiableCredential
+		normalizedVC, err := marshal.NormalizeDocument([]byte(raw), pluralContext, marshal.Plural(typeKey), marshal.Plural(credentialSubjectKey), marshal.Plural(proofKey))
+		if err != nil {
+			return nil, err
+		}
+		alias := Alias{}
+		err = json.Unmarshal(normalizedVC, &alias)
+		if err != nil {
+			return nil, err
+		}
+		alias.format = JSONLDCredentialProofFormat
+		alias.raw = raw
+		result := VerifiableCredential(alias)
+		return &result, err
+	} else {
+		// Assume JWT format
+		token, err := jwt.Parse([]byte(raw))
+		if err != nil {
+			return nil, err
+		}
+		var result VerifiableCredential
+		if innerVCInterf := token.PrivateClaims()["vc"]; innerVCInterf != nil {
+			innerVCJSON, _ := json.Marshal(innerVCInterf)
+			err = json.Unmarshal(innerVCJSON, &result)
+			if err != nil {
+				return nil, fmt.Errorf("invalid JWT 'vc' claim: %w", err)
+			}
+		}
+		// parse exp
+		exp := token.Expiration()
+		result.ExpirationDate = &exp
+		// parse iss
+		if iss, err := parseURIClaim(token, jwt.IssuerKey); err != nil {
+			return nil, err
+		} else if iss != nil {
+			result.Issuer = *iss
+		}
+		// parse nbf
+		result.IssuanceDate = token.NotBefore()
+		// parse sub
+		if token.Subject() != "" {
+			for _, credentialSubjectInterf := range result.CredentialSubject {
+				credentialSubject, isMap := credentialSubjectInterf.(map[string]interface{})
+				if isMap {
+					credentialSubject["id"] = token.Subject()
+				}
+			}
+		}
+		var subject string
+		if subjectDID, err := result.SubjectDID(); err != nil {
+			// credentialSubject.id is optional
+			if !errors.Is(err, errCredentialSubjectWithoutID) {
+				return nil, fmt.Errorf("invalid JWT 'sub' claim: %w", err)
+			}
+		} else if subjectDID != nil {
+			subject = subjectDID.String()
+		}
+		if token.Subject() != subject {
+			return nil, errors.New("invalid JWT 'sub' claim: must equal credentialSubject.id")
+		}
+		// parse jti
+		if jti, err := parseURIClaim(token, jwt.JwtIDKey); err != nil {
+			return nil, err
+		} else if jti != nil {
+			result.ID = jti
+		}
+		result.format = JWTCredentialsProofFormat
+		result.raw = raw
+		result.token = token
+		return &result, nil
+	}
+}
+
 // VerifiableCredential represents a credential as defined by the Verifiable Credentials Data Model 1.0 specification (https://www.w3.org/TR/vc-data-model/).
 type VerifiableCredential struct {
 	// Context defines the json-ld context to dereference the URIs
@@ -52,6 +142,29 @@ type VerifiableCredential struct {
 	CredentialSubject []interface{} `json:"credentialSubject"`
 	// Proof contains the cryptographic proof(s). It must be extracted using the Proofs method or UnmarshalProofValue method for non-generic proof fields.
 	Proof []interface{} `json:"proof"`
+
+	format string
+	raw    string
+	token  jwt.Token
+}
+
+// Format returns the format of the credential (e.g. jwt_vc or ldp_vc).
+func (vc VerifiableCredential) Format() string {
+	return vc.format
+}
+
+// Raw returns the source of the credential as it was parsed.
+func (vc VerifiableCredential) Raw() string {
+	return vc.raw
+}
+
+// JWT returns the JWT token if the credential was parsed from a JWT.
+func (vc VerifiableCredential) JWT() jwt.Token {
+	if vc.token == nil {
+		return nil
+	}
+	token, _ := vc.token.Clone()
+	return token
 }
 
 // CredentialStatus defines the method on how to determine a credential is revoked.
@@ -87,18 +200,19 @@ func (vc VerifiableCredential) MarshalJSON() ([]byte, error) {
 }
 
 func (vc *VerifiableCredential) UnmarshalJSON(b []byte) error {
-	type Alias VerifiableCredential
-	normalizedVC, err := marshal.NormalizeDocument(b, pluralContext, marshal.Plural(typeKey), marshal.Plural(credentialSubjectKey), marshal.Plural(proofKey))
-	if err != nil {
-		return err
+	var str string
+	if len(b) > 0 && b[0] == '"' {
+		if err := json.Unmarshal(b, &str); err != nil {
+			return err
+		}
+	} else {
+		str = string(b)
 	}
-	tmp := Alias{}
-	err = json.Unmarshal(normalizedVC, &tmp)
-	if err != nil {
-		return err
+	credential, err := ParseVerifiableCredential(str)
+	if err == nil {
+		*vc = *credential
 	}
-	*vc = (VerifiableCredential)(tmp)
-	return nil
+	return err
 }
 
 // UnmarshalProofValue unmarshalls the proof to the given proof type. Always pass a slice as target since there could be multiple proofs.
@@ -147,7 +261,7 @@ func (vc VerifiableCredential) SubjectDID() (*did.DID, error) {
 		}
 	}
 	if subjectID.Empty() {
-		return nil, errors.New("unable to get subject DID from VC: credential subjects have no ID")
+		return nil, fmt.Errorf("unable to get subject DID from VC: %w", errCredentialSubjectWithoutID)
 	}
 	return &subjectID, nil
 }

--- a/vc/vp.go
+++ b/vc/vp.go
@@ -117,6 +117,11 @@ func (vp VerifiablePresentation) JWT() jwt.Token {
 	return token
 }
 
+// Raw returns the source of the presentation as it was parsed.
+func (vp VerifiablePresentation) Raw() string {
+	return vp.raw
+}
+
 // Proofs returns the basic proofs for this presentation. For specific proof contents, UnmarshalProofValue must be used.
 func (vp VerifiablePresentation) Proofs() ([]Proof, error) {
 	var (

--- a/vc/vp.go
+++ b/vc/vp.go
@@ -47,6 +47,7 @@ type VerifiablePresentation struct {
 
 // ParseVerifiablePresentation parses a Verifiable Presentation from a string, which can be either in JSON-LD or JWT format.
 // If the format is JWT, the parsed token can be retrieved using JWT().
+// Note that it does not do any signature checking.
 func ParseVerifiablePresentation(raw string) (*VerifiablePresentation, error) {
 	if strings.HasPrefix(raw, "{") {
 		// Assume JSON-LD format

--- a/vc/vp.go
+++ b/vc/vp.go
@@ -55,6 +55,7 @@ func ParseVerifiablePresentation(raw string) (*VerifiablePresentation, error) {
 		var result VerifiablePresentation
 		err := json.Unmarshal([]byte(raw), &result)
 		if err == nil {
+			result.raw = raw
 			result.format = JSONLDPresentationProofFormat
 		}
 		return &result, err
@@ -114,6 +115,9 @@ func (vp VerifiablePresentation) Format() string {
 
 // JWT returns the JWT token if the presentation was parsed from a JWT.
 func (vp VerifiablePresentation) JWT() jwt.Token {
+	if vp.token == nil {
+		return nil
+	}
 	token, _ := vp.token.Clone()
 	return token
 }

--- a/vc/vp_test.go
+++ b/vc/vp_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	ssi "github.com/nuts-foundation/go-did"
 	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -220,5 +221,15 @@ func TestParseVerifiablePresentation(t *testing.T) {
 		vc := vp.VerifiableCredential[0]
 		assert.Equal(t, JWTCredentialsProofFormat, vc.Format())
 		assert.Equal(t, "http://example.edu/credentials/3732", vc.ID.String())
+	})
+	t.Run("json.UnmarshalJSON for JWT-VP wrapped inside other document", func(t *testing.T) {
+		type Wrapper struct {
+			VP VerifiablePresentation `json:"vp"`
+		}
+		input := `{"vp":"` + strings.ReplaceAll(jwtPresentation, "\n", "") + `"}`
+		var expected Wrapper
+		err := json.Unmarshal([]byte(input), &expected)
+		require.NoError(t, err)
+		assert.Equal(t, JWTPresentationProofFormat, expected.VP.Format())
 	})
 }

--- a/vc/vp_test.go
+++ b/vc/vp_test.go
@@ -2,65 +2,101 @@ package vc
 
 import (
 	"encoding/json"
-	"testing"
-
 	ssi "github.com/nuts-foundation/go-did"
+	"github.com/stretchr/testify/require"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+// jwtPresentation is taken from https://www.w3.org/TR/vc-data-model/#example-verifiable-presentation-using-jwt-compact-serialization-non-normative
+const jwtPresentation = `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRpZDpleGFtcGxlOjB4YWJjI2tleTEifQ.e
+yJpc3MiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJqdGkiOiJ1cm46d
+XVpZDozOTc4MzQ0Zi04NTk2LTRjM2EtYTk3OC04ZmNhYmEzOTAzYzUiLCJhdWQiOiJkaWQ6ZXhhbXBsZ
+To0YTU3NTQ2OTczNDM2ZjZmNmM0YTRhNTc1NzMiLCJuYmYiOjE1NDE0OTM3MjQsImlhdCI6MTU0MTQ5M
+zcyNCwiZXhwIjoxNTczMDI5NzIzLCJub25jZSI6IjM0M3MkRlNGRGEtIiwidnAiOnsiQGNvbnRleHQiO
+lsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3d3dy53My5vc
+mcvMjAxOC9jcmVkZW50aWFscy9leGFtcGxlcy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVQcmVzZW50Y
+XRpb24iLCJDcmVkZW50aWFsTWFuYWdlclByZXNlbnRhdGlvbiJdLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhb
+CI6WyJleUpoYkdjaU9pSlNVekkxTmlJc0luUjVjQ0k2SWtwWFZDSXNJbXRwWkNJNkltUnBaRHBsZUdGd
+GNHeGxPbUZpWm1VeE0yWTNNVEl4TWpBME16RmpNamMyWlRFeVpXTmhZaU5yWlhsekxURWlmUS5leUp6Z
+FdJaU9pSmthV1E2WlhoaGJYQnNaVHBsWW1abFlqRm1OekV5WldKak5tWXhZekkzTm1VeE1tVmpNakVpT
+ENKcWRHa2lPaUpvZEhSd09pOHZaWGhoYlhCc1pTNWxaSFV2WTNKbFpHVnVkR2xoYkhNdk16Y3pNaUlzS
+W1semN5STZJbWgwZEhCek9pOHZaWGhoYlhCc1pTNWpiMjB2YTJWNWN5OW1iMjh1YW5kcklpd2libUptS
+WpveE5UUXhORGt6TnpJMExDSnBZWFFpT2pFMU5ERTBPVE0zTWpRc0ltVjRjQ0k2TVRVM016QXlPVGN5T
+Xl3aWJtOXVZMlVpT2lJMk5qQWhOak0wTlVaVFpYSWlMQ0oyWXlJNmV5SkFZMjl1ZEdWNGRDSTZXeUpvZ
+EhSd2N6b3ZMM2QzZHk1M015NXZjbWN2TWpBeE9DOWpjbVZrWlc1MGFXRnNjeTkyTVNJc0ltaDBkSEJ6T
+2k4dmQzZDNMbmN6TG05eVp5OHlNREU0TDJOeVpXUmxiblJwWVd4ekwyVjRZVzF3YkdWekwzWXhJbDBzS
+W5SNWNHVWlPbHNpVm1WeWFXWnBZV0pzWlVOeVpXUmxiblJwWVd3aUxDSlZibWwyWlhKemFYUjVSR1ZuY
+21WbFEzSmxaR1Z1ZEdsaGJDSmRMQ0pqY21Wa1pXNTBhV0ZzVTNWaWFtVmpkQ0k2ZXlKa1pXZHlaV1VpT
+25zaWRIbHdaU0k2SWtKaFkyaGxiRzl5UkdWbmNtVmxJaXdpYm1GdFpTSTZJanh6Y0dGdUlHeGhibWM5S
+jJaeUxVTkJKejVDWVdOallXeGhkWExEcVdGMElHVnVJRzExYzJseGRXVnpJRzUxYmNPcGNtbHhkV1Z6U
+EM5emNHRnVQaUo5ZlgxOS5LTEpvNUdBeUJORDNMRFRuOUg3RlFva0VzVUVpOGpLd1hoR3ZvTjNKdFJhN
+TF4ck5EZ1hEYjBjcTFVVFlCLXJLNEZ0OVlWbVIxTklfWk9GOG9HY183d0FwOFBIYkYySGFXb2RRSW9PQ
+nh4VC00V05xQXhmdDdFVDZsa0gtNFM2VXgzclNHQW1jek1vaEVFZjhlQ2VOLWpDOFdla2RQbDZ6S1pRa
+jBZUEIxcng2WDAteGxGQnM3Y2w2V3Q4cmZCUF90WjlZZ1ZXclFtVVd5cFNpb2MwTVV5aXBobXlFYkxaY
+WdUeVBsVXlmbEdsRWRxclpBdjZlU2U2UnR4Snk2TTEtbEQ3YTVIVHphbllUV0JQQVVIRFpHeUdLWGRKd
+y1XX3gwSVdDaEJ6STh0M2twRzI1M2ZnNlYzdFBnSGVLWEU5NGZ6X1FwWWZnLS03a0xzeUJBZlFHYmciX
+X19.ft_Eq4IniBrr7gtzRfrYj8Vy1aPXuFZU-6_ai0wvaKcsrzI4JkQEKTvbJwdvIeuGuTqy7ipO-EYi
+7V4TvonPuTRdpB7ZHOlYlbZ4wA9WJ6mSVSqDACvYRiFvrOFmie8rgm6GacWatgO4m4NqiFKFko3r58Lu
+eFfGw47NK9RcfOkVQeHCq4btaDqksDKeoTrNysF4YS89INa-prWomrLRAhnwLOo1Etp3E4ESAxg73CR2
+kA5AoMbf5KtFueWnMcSbQkMRdWcGC1VssC0tB0JffVjq7ZV6OTyV4kl1-UVgiPLXUTpupFfLRhf9QpqM
+BjYgP62KvhIvW8BbkGUelYMetA`
+
 func TestVerifiablePresentation_MarshalJSON(t *testing.T) {
-	t.Run("ok - single credential and proof", func(t *testing.T) {
-		input := VerifiablePresentation{
-			VerifiableCredential: []VerifiableCredential{
-				{
-					Type: []ssi.URI{VerifiableCredentialTypeV1URI()},
+	t.Run("JSON-LD", func(t *testing.T) {
+		t.Run("ok - single credential and proof", func(t *testing.T) {
+			input := VerifiablePresentation{
+				VerifiableCredential: []VerifiableCredential{
+					{
+						Type: []ssi.URI{VerifiableCredentialTypeV1URI()},
+					},
 				},
-			},
-			Proof: []interface{}{
-				JSONWebSignature2020Proof{
-					Jws: "",
+				Proof: []interface{}{
+					JSONWebSignature2020Proof{
+						Jws: "",
+					},
 				},
-			},
-		}
+			}
 
-		bytes, err := json.Marshal(input)
+			bytes, err := json.Marshal(input)
 
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.Contains(t, string(bytes), "\"proof\":{")
-		assert.Contains(t, string(bytes), "\"verifiableCredential\":{")
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Contains(t, string(bytes), "\"proof\":{")
+			assert.Contains(t, string(bytes), "\"verifiableCredential\":{")
+		})
+		t.Run("ok - multiple credential and proof", func(t *testing.T) {
+			input := VerifiablePresentation{
+				VerifiableCredential: []VerifiableCredential{
+					{
+						Type: []ssi.URI{VerifiableCredentialTypeV1URI()},
+					},
+					{
+						Type: []ssi.URI{VerifiableCredentialTypeV1URI()},
+					},
+				},
+				Proof: []interface{}{
+					JSONWebSignature2020Proof{
+						Jws: "",
+					},
+					JSONWebSignature2020Proof{
+						Jws: "",
+					},
+				},
+			}
+
+			bytes, err := json.Marshal(input)
+
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Contains(t, string(bytes), "\"proof\":[")
+			assert.Contains(t, string(bytes), "\"verifiableCredential\":[")
+		})
 	})
 
-	t.Run("ok - multiple credential and proof", func(t *testing.T) {
-		input := VerifiablePresentation{
-			VerifiableCredential: []VerifiableCredential{
-				{
-					Type: []ssi.URI{VerifiableCredentialTypeV1URI()},
-				},
-				{
-					Type: []ssi.URI{VerifiableCredentialTypeV1URI()},
-				},
-			},
-			Proof: []interface{}{
-				JSONWebSignature2020Proof{
-					Jws: "",
-				},
-				JSONWebSignature2020Proof{
-					Jws: "",
-				},
-			},
-		}
-
-		bytes, err := json.Marshal(input)
-
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.Contains(t, string(bytes), "\"proof\":[")
-		assert.Contains(t, string(bytes), "\"verifiableCredential\":[")
-	})
 }
 
 func TestVerifiablePresentation_UnmarshalProof(t *testing.T) {
@@ -148,5 +184,36 @@ func TestVerifiablePresentation_ContainsContext(t *testing.T) {
 	t.Run("false", func(t *testing.T) {
 		u, _ := ssi.ParseURI("context")
 		assert.False(t, input.ContainsContext(*u))
+	})
+}
+
+func TestParseVerifiablePresentation(t *testing.T) {
+	t.Run("JSON-LD", func(t *testing.T) {
+		vp, err := ParseVerifiablePresentation(`{
+		  "id":"did:example:123#vp-1",
+		  "@context":["https://www.w3.org/2018/credentials/v1"]
+		}`)
+		require.NoError(t, err)
+		require.NotNil(t, vp)
+		assert.Equal(t, JSONLDPresentationProofFormat, vp.Format())
+		assert.Equal(t, "did:example:123#vp-1", vp.ID.String())
+		assert.Equal(t, []ssi.URI{VCContextV1URI()}, vp.Context)
+	})
+	t.Run("JWT", func(t *testing.T) {
+		vp, err := ParseVerifiablePresentation(jwtPresentation)
+		require.NoError(t, err)
+		require.NotNil(t, vp)
+		assert.Equal(t, JWTPresentationProofFormat, vp.Format())
+		assert.Equal(t, "did:example:ebfeb1f712ebc6f1c276e12ec21", vp.Holder.String())
+		assert.Equal(t, "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5", vp.ID.String())
+		assert.Equal(t, []string{"did:example:4a57546973436f6f6c4a4a57573"}, vp.JWT().Audience())
+		assert.Len(t, vp.Type, 2)
+		assert.True(t, vp.IsType(ssi.MustParseURI("VerifiablePresentation")))
+		assert.True(t, vp.IsType(ssi.MustParseURI("CredentialManagerPresentation")))
+		// Assert contained JWT VerifiableCredential was unmarshalled
+		assert.Len(t, vp.VerifiableCredential, 1)
+		vc := vp.VerifiableCredential[0]
+		assert.Equal(t, JWTCredentialsProofFormat, vc.Format())
+		assert.Equal(t, "http://example.edu/credentials/3732", vc.ID.String())
 	})
 }

--- a/vc/vp_test.go
+++ b/vc/vp_test.go
@@ -189,15 +189,18 @@ func TestVerifiablePresentation_ContainsContext(t *testing.T) {
 
 func TestParseVerifiablePresentation(t *testing.T) {
 	t.Run("JSON-LD", func(t *testing.T) {
-		vp, err := ParseVerifiablePresentation(`{
+		raw := `{
 		  "id":"did:example:123#vp-1",
 		  "@context":["https://www.w3.org/2018/credentials/v1"]
-		}`)
+		}`
+		vp, err := ParseVerifiablePresentation(raw)
 		require.NoError(t, err)
 		require.NotNil(t, vp)
 		assert.Equal(t, JSONLDPresentationProofFormat, vp.Format())
 		assert.Equal(t, "did:example:123#vp-1", vp.ID.String())
 		assert.Equal(t, []ssi.URI{VCContextV1URI()}, vp.Context)
+		assert.Nil(t, vp.JWT())
+		assert.Equal(t, raw, vp.Raw())
 	})
 	t.Run("JWT", func(t *testing.T) {
 		vp, err := ParseVerifiablePresentation(jwtPresentation)
@@ -210,6 +213,8 @@ func TestParseVerifiablePresentation(t *testing.T) {
 		assert.Len(t, vp.Type, 2)
 		assert.True(t, vp.IsType(ssi.MustParseURI("VerifiablePresentation")))
 		assert.True(t, vp.IsType(ssi.MustParseURI("CredentialManagerPresentation")))
+		assert.NotNil(t, vp.JWT())
+		assert.Equal(t, jwtPresentation, vp.Raw())
 		// Assert contained JWT VerifiableCredential was unmarshalled
 		assert.Len(t, vp.VerifiableCredential, 1)
 		vc := vp.VerifiableCredential[0]


### PR DESCRIPTION
Required for supporting it in the Nuts node; we can now use the same struct for representing in either JSON-LD or JWT format. I moved most of the `UnmarshalJSON` code to the `Parse` functions (which it now calls), to accomodate parsing VCs and VPs outside of JSON documents.

Specification: https://www.w3.org/TR/vc-data-model/#json-web-token
Includes https://github.com/nuts-foundation/go-did/pull/84

TODO:
- [x] Extra test coverage