### PR TITLE
credentialStatus.id must be a URI, not URL

### DIFF
--- a/vc/vc.go
+++ b/vc/vc.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/nuts-foundation/go-did/did"
-	"net/url"
 	"time"
 
 	ssi "github.com/nuts-foundation/go-did"
@@ -57,7 +56,7 @@ type VerifiableCredential struct {
 
 // CredentialStatus defines the method on how to determine a credential is revoked.
 type CredentialStatus struct {
-	ID   url.URL `json:"id"`
+	ID   ssi.URI `json:"id"`
 	Type string  `json:"type"`
 }
 

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -3,6 +3,7 @@ package vc
 import (
 	"encoding/json"
 	ssi "github.com/nuts-foundation/go-did"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,25 @@ func TestVerifiableCredential_UnmarshalCredentialSubject(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, "test", target[0].Name)
+	})
+}
+
+func TestCredentialStatus(t *testing.T) {
+	t.Run("can unmarshal JWT VC Presentation Profile JWT-VC example", func(t *testing.T) {
+		// CredentialStatus example taken from https://identity.foundation/jwt-vc-presentation-profile/#vc-jwt
+		// Regression: earlier defined credentialStatus.id as url.URL, which breaks since it's specified as URI by the core specification.
+		expectedJSON := `{
+      "id": "urn:uuid:7facf41c-1dc5-486b-87e6-587d015e76d7?bit-index=10",
+      "type": "RevocationList2021Status",
+      "statusListIndex": "10",
+      "statusListCredential": "did:ion:EiD7M8RYnUuir2bm21uu-5YmWcqqQEie-T-jYEOEBeEWJQ:eyJkZWx0YSI6eyJwYXRjaGVzIjpbeyJhY3Rpb24iOiJyZXBsYWNlIiwiZG9jdW1lbnQiOnsicHVibGljS2V5cyI6W3siaWQiOiJzaWduIiwicHVibGljS2V5SndrIjp7ImNydiI6InNlY3AyNTZrMSIsImt0eSI6IkVDIiwieCI6InNnamhTdVFsZkdYVjg1QlVSWkg5aEtQR2RhTDRlYmdSN0dERERFbkJteXMiLCJ5IjoiRGw4Z3dqazRPN2h5cDVqVjZjUjFCT3l0el9TSUZtN0ljWUlsLXBqd1JUVSJ9LCJwdXJwb3NlcyI6WyJhdXRoZW50aWNhdGlvbiJdLCJ0eXBlIjoiRWNkc2FTZWNwMjU2azFWZXJpZmljYXRpb25LZXkyMDE5In1dfX1dLCJ1cGRhdGVDb21taXRtZW50IjoiRWlBUjZWbjlHeGJiSFhEcDBoZjl6NV9ZT3gzcFJhZWd5LVFUdEp3YjNDcUdCdyJ9LCJzdWZmaXhEYXRhIjp7ImRlbHRhSGFzaCI6IkVpQ05hbDZYUnV5VjFkX2p2UlZEbmpFTXNqSUJLZjE2VzYxdDF2cndOZ1QtbVEiLCJyZWNvdmVyeUNvbW1pdG1lbnQiOiJFaUJoOWRrSDBEdVZOUGcyTnJmWi0zZ1BmYzZXVl9CN3dOZ1hNZWlBekxBaDFnIn19?service=IdentityHub&queries=W3sibWV0aG9kIjoiQ29sbGVjdGlvbnNRdWVyeSIsInNjaGVtYSI6Imh0dHBzOi8vdzNpZC5vcmcvdmMtc3RhdHVzLWxpc3QtMjAyMS92MSIsIm9iamVjdElkIjoiZjljYTFmNDAtODg0NS00NWE1LTgwNWYtYzJlNWJjNDZhN2I5In1d"
+    }`
+		var actual CredentialStatus
+
+		err := json.Unmarshal([]byte(expectedJSON), &actual)
+		require.NoError(t, err)
+
+		assert.Equal(t, "urn:uuid:7facf41c-1dc5-486b-87e6-587d015e76d7?bit-index=10", actual.ID.String())
 	})
 }
 


### PR DESCRIPTION
Unmarshalling (non-normative) example of JWT-VC presentation profile breaks (https://identity.foundation/jwt-vc-presentation-profile/#vc-jwt). It should be a URI (https://www.w3.org/TR/vc-data-model/#status).