### PR TITLE
Bugfixes for integration

### DIFF
--- a/internal/marshal/marshal.go
+++ b/internal/marshal/marshal.go
@@ -70,3 +70,12 @@ func PluralValueOrMap(key string) Normalizer {
 		}
 	}
 }
+
+// PruneString returns a Normalizer that removes keys that have a string value match a given string.
+func PruneString(key string, match string) Normalizer {
+	return func(m map[string]interface{}) {
+		if value, ok := m[key]; ok && value == match {
+			delete(m, key)
+		}
+	}
+}

--- a/internal/marshal/marshal.go
+++ b/internal/marshal/marshal.go
@@ -70,12 +70,3 @@ func PluralValueOrMap(key string) Normalizer {
 		}
 	}
 }
-
-// PruneString returns a Normalizer that removes keys that have a string value match a given string.
-func PruneString(key string, match string) Normalizer {
-	return func(m map[string]interface{}) {
-		if value, ok := m[key]; ok && value == match {
-			delete(m, key)
-		}
-	}
-}

--- a/vc/vc.go
+++ b/vc/vc.go
@@ -76,7 +76,7 @@ func parseJWTCredential(raw string) (*VerifiableCredential, error) {
 		}
 	}
 	// parse exp
-	if _, ok := token.Get("exp"); ok {
+	if _, ok := token.Get(jwt.ExpirationKey); ok {
 		exp := token.Expiration()
 		result.ExpirationDate = &exp
 	}
@@ -87,7 +87,9 @@ func parseJWTCredential(raw string) (*VerifiableCredential, error) {
 		result.Issuer = *iss
 	}
 	// parse nbf
-	result.IssuanceDate = token.NotBefore()
+	if _, ok := token.Get(jwt.NotBeforeKey); ok {
+		result.IssuanceDate = token.NotBefore()
+	}
 	// parse sub
 	if token.Subject() != "" {
 		for _, credentialSubjectInterf := range result.CredentialSubject {

--- a/vc/vc.go
+++ b/vc/vc.go
@@ -302,7 +302,8 @@ func (vc VerifiableCredential) ContainsContext(context ssi.URI) bool {
 type JWTSigner func(ctx context.Context, claims map[string]interface{}, headers map[string]interface{}) (string, error)
 
 // CreateJWTVerifiableCredential creates a JWT Verifiable Credential from the given credential template.
-// For signing the actual JWT it calls the given signer.
+// For signing the actual JWT it calls the given signer, which must return the created JWT in string format.
+// Note: the signer is responsible for adding the right key claims (e.g. `kid`).
 func CreateJWTVerifiableCredential(ctx context.Context, template VerifiableCredential, signer JWTSigner) (*VerifiableCredential, error) {
 	subjectDID, err := template.SubjectDID()
 	if err != nil {
@@ -331,5 +332,5 @@ func CreateJWTVerifiableCredential(ctx context.Context, template VerifiableCrede
 	if err != nil {
 		return nil, fmt.Errorf("unable to sign JWT credential: %w", err)
 	}
-	return ParseVerifiableCredential(token)
+	return parseJWTCredential(token)
 }

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -27,7 +27,9 @@ BND3LDTn9H7FQokEsUEi8jKwXhGvoN3JtRa51xrNDgXDb0cq1UTYB-rK4Ft9YVmR1NI_ZOF8oGc_7wAp
 txJy6M1-lD7a5HTzanYTWBPAUHDZGyGKXdJw-W_x0IWChBzI8t3kpG253fg6V3tPgHeKXE94fz_QpYfg
 --7kLsyBAfQGbg`
 
-func TestVerifiableCredential_UnmarshalJSON(t *testing.T) {
+// TestVerifiableCredential_JSONMarshalling tests JSON marshalling of VerifiableCredential.
+// Credentials in JSON-LD format are marshalled JSON object, while JWT credentials are marshalled as JSON string.
+func TestVerifiableCredential_JSONMarshalling(t *testing.T) {
 	t.Run("JSON-LD", func(t *testing.T) {
 		input := VerifiableCredential{}
 		raw := `{
@@ -43,6 +45,10 @@ func TestVerifiableCredential_UnmarshalJSON(t *testing.T) {
 		assert.Equal(t, JSONLDCredentialProofFormat, input.Format())
 		assert.Equal(t, raw, input.Raw())
 		assert.Nil(t, input.JWT())
+		// Should marshal into JSON object
+		marshalled, err := json.Marshal(input)
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(string(marshalled), "{"))
 	})
 	t.Run("JWT", func(t *testing.T) {
 		input := VerifiableCredential{}
@@ -52,9 +58,13 @@ func TestVerifiableCredential_UnmarshalJSON(t *testing.T) {
 		assert.Equal(t, []ssi.URI{ssi.MustParseURI("VerifiableCredential"), ssi.MustParseURI("UniversityDegreeCredential")}, input.Type)
 		assert.Len(t, input.CredentialSubject, 1)
 		assert.NotNil(t, input.CredentialSubject[0].(map[string]interface{})["degree"])
-		assert.Equal(t, JWTCredentialsProofFormat, input.Format())
+		assert.Equal(t, JWTCredentialProofFormat, input.Format())
 		assert.Equal(t, raw, input.Raw())
 		assert.NotNil(t, input.JWT())
+		// Should marshal into JSON string
+		marshalled, err := json.Marshal(input)
+		require.NoError(t, err)
+		assert.JSONEq(t, `"`+raw+`"`, string(marshalled))
 	})
 }
 

--- a/vc/vp.go
+++ b/vc/vp.go
@@ -155,19 +155,21 @@ func (vp VerifiablePresentation) Proofs() ([]Proof, error) {
 }
 
 func (vp VerifiablePresentation) MarshalJSON() ([]byte, error) {
-	switch vp.format {
-	case JWTPresentationProofFormat:
-		return json.Marshal(vp.raw)
-	case JSONLDPresentationProofFormat:
-		fallthrough
-	default:
-		type alias VerifiablePresentation
-		tmp := alias(vp)
-		if data, err := json.Marshal(tmp); err != nil {
-			return nil, err
-		} else {
-			return marshal.NormalizeDocument(data, pluralContext, marshal.Unplural(typeKey), marshal.Unplural(verifiableCredentialKey), marshal.Unplural(proofKey))
+	if vp.raw != "" {
+		// Presentation instance created through ParseVerifiablePresentation()
+		if vp.format == JWTPresentationProofFormat {
+			// Marshal as JSON string
+			return json.Marshal(vp.raw)
 		}
+		// JSON-LD, already in JSON format so return as-is
+		return []byte(vp.raw), nil
+	}
+	type alias VerifiablePresentation
+	tmp := alias(vp)
+	if data, err := json.Marshal(tmp); err != nil {
+		return nil, err
+	} else {
+		return marshal.NormalizeDocument(data, pluralContext, marshal.Unplural(typeKey), marshal.Unplural(verifiableCredentialKey), marshal.Unplural(proofKey))
 	}
 }
 

--- a/vc/vp_test.go
+++ b/vc/vp_test.go
@@ -219,7 +219,7 @@ func TestParseVerifiablePresentation(t *testing.T) {
 		// Assert contained JWT VerifiableCredential was unmarshalled
 		assert.Len(t, vp.VerifiableCredential, 1)
 		vc := vp.VerifiableCredential[0]
-		assert.Equal(t, JWTCredentialsProofFormat, vc.Format())
+		assert.Equal(t, JWTCredentialProofFormat, vc.Format())
 		assert.Equal(t, "http://example.edu/credentials/3732", vc.ID.String())
 	})
 	t.Run("json.UnmarshalJSON for JWT-VP wrapped inside other document", func(t *testing.T) {


### PR DESCRIPTION
When integrating in Nuts node, I came across a few bugs:

- Typo in `JWTCredentialsProofFormat` const name
- `MarshalJSON()` for Verifiable Credentials in JWT format returned the VC as JSON (as if it were JSON-LD), instead of the parsed JWT VC
- JWT VCs contained null/empty values for properties that are specified as JWT claims (`issuanceDate`, `issuer`, `proof`). Moved JWT creation function from Nuts node to this library to create JWT credential without setting null/empty properties.
- Made `expirationDate` in Verifiable Credential in JWT format optional (now led to a zero-ed `time.Time`)