### PR TITLE
Support relative DID URLs for verification method IDs

### DIFF
--- a/did/did.go
+++ b/did/did.go
@@ -7,14 +7,11 @@ import (
 	"fmt"
 	"github.com/nuts-foundation/go-did"
 	"net/url"
-	"regexp"
 	"strings"
 )
 
 var _ fmt.Stringer = DID{}
 var _ encoding.TextMarshaler = DID{}
-
-var didPattern = regexp.MustCompile(`^did:([a-z0-9]+):((?:(?:[a-zA-Z0-9.\-_:])+|(?:%[0-9a-fA-F]{2})+)+)(/.*?|)(\?.*?|)(#.*|)$`)
 
 // DIDContextV1 contains the JSON-LD context for a DID Document
 const DIDContextV1 = "https://www.w3.org/ns/did/v1"
@@ -33,19 +30,6 @@ type DID struct {
 	// DecodedID is the method-specific ID, in unescaped form.
 	// It is only set during parsing, and not used by the String() method.
 	DecodedID string
-	// Path is the DID path without the leading '/', in escaped form.
-	Path string
-	// DecodedPath is the DID path without the leading '/', in unescaped form.
-	// It is only set during parsing, and not used by the String() method.
-	DecodedPath string
-	// Query contains the DID query key-value pairs, in unescaped form.
-	// String() will escape the values again, and order the keys alphabetically.
-	Query url.Values
-	// Fragment is the DID fragment without the leading '#', in escaped form.
-	Fragment string
-	// DecodedFragment is the DID fragment without the leading '#', in unescaped form.
-	// It is only set during parsing, and not used by the String() method.
-	DecodedFragment string
 }
 
 // Empty checks whether the DID is set or not
@@ -58,15 +42,9 @@ func (d DID) String() string {
 	if d.Empty() {
 		return ""
 	}
-	result := "did:" + d.Method + ":" + d.ID
-	if d.Path != "" {
-		result += "/" + d.Path
-	}
-	if len(d.Query) > 0 {
-		result += "?" + d.Query.Encode()
-	}
-	if d.Fragment != "" {
-		result += "#" + d.Fragment
+	var result string
+	if d.Method != "" {
+		result += "did:" + d.Method + ":" + d.ID
 	}
 	return result
 }
@@ -77,17 +55,9 @@ func (d DID) MarshalText() ([]byte, error) {
 }
 
 // Equals checks whether the DID equals to another DID.
-// When the DIDs
 // The check is case-sensitive.
 func (d DID) Equals(other DID) bool {
-	return d.cleanup().String() == other.cleanup().String()
-}
-
-func (d DID) cleanup() DID {
-	if len(d.Query) == 0 {
-		d.Query = nil
-	}
-	return d
+	return d.String() == other.String()
 }
 
 // UnmarshalJSON unmarshals a DID encoded as JSON string, e.g.:
@@ -98,7 +68,7 @@ func (d *DID) UnmarshalJSON(bytes []byte) error {
 	if err != nil {
 		return ErrInvalidDID.wrap(err)
 	}
-	tmp, err := ParseDIDURL(didString)
+	tmp, err := ParseDID(didString)
 	if err != nil {
 		return err
 	}
@@ -106,112 +76,47 @@ func (d *DID) UnmarshalJSON(bytes []byte) error {
 	return nil
 }
 
-func (d *DID) IsURL() bool {
-	return d.Fragment != "" || len(d.Query) != 0 || d.Path != ""
-}
-
 // MarshalJSON marshals the DID to a JSON string
 func (d DID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.String())
 }
 
-// URI converts the DID to an URI.
+// URI converts the DID to a URI.
 // URIs are used in Verifiable Credentials
 func (d DID) URI() ssi.URI {
 	return ssi.URI{
 		URL: url.URL{
-			Scheme:   "did",
-			Opaque:   fmt.Sprintf("%s:%s", d.Method, url.PathEscape(d.ID)),
-			Fragment: d.Fragment,
+			Scheme: "did",
+			Opaque: fmt.Sprintf("%s:%s", d.Method, url.PathEscape(d.ID)),
 		},
 	}
-}
-
-// WithoutURL returns a copy of the DID without URL parts (fragment, query, path).
-func (d DID) WithoutURL() DID {
-	return DID{
-		Method:    d.Method,
-		ID:        d.ID,
-		DecodedID: d.DecodedID,
-	}
-}
-
-// ParseDIDURL parses a DID URL.
-// https://www.w3.org/TR/did-core/#did-url-syntax
-// A DID URL is a URL that builds on the DID scheme.
-func ParseDIDURL(input string) (*DID, error) {
-	// There are 6 submatches (base 0)
-	// 0. complete DID
-	// 1. method
-	// 2. id
-	// 3. path (starting with '/')
-	// 4. query (starting with '?')
-	// 5. fragment (starting with '#')
-	matches := didPattern.FindStringSubmatch(input)
-	if len(matches) == 0 {
-		return nil, ErrInvalidDID
-	}
-
-	result := DID{
-		Method:   matches[1],
-		ID:       matches[2],
-		Path:     strings.TrimPrefix(matches[3], "/"),
-		Fragment: strings.TrimPrefix(matches[5], "#"),
-	}
-	var err error
-	result.DecodedID, err = url.PathUnescape(result.ID)
-	if err != nil {
-		return nil, ErrInvalidDID.wrap(fmt.Errorf("invalid ID: %w", err))
-	}
-	result.DecodedPath, err = url.PathUnescape(result.Path)
-	if err != nil {
-		return nil, ErrInvalidDID.wrap(fmt.Errorf("invalid path: %w", err))
-	}
-	result.DecodedFragment, err = url.PathUnescape(result.Fragment)
-	if err != nil {
-		return nil, ErrInvalidDID.wrap(fmt.Errorf("invalid fragment: %w", err))
-	}
-	result.Query, err = url.ParseQuery(strings.TrimPrefix(matches[4], "?"))
-	if err != nil {
-		return nil, ErrInvalidDID.wrap(err)
-	}
-	result = result.cleanup()
-	return &result, nil
 }
 
 // ParseDID parses a raw DID.
 // If the input contains a path, query or fragment, use the ParseDIDURL instead.
 // If it can't be parsed, an error is returned.
 func ParseDID(input string) (*DID, error) {
-	did, err := ParseDIDURL(input)
+	didURL, err := ParseDIDURL(input)
 	if err != nil {
 		return nil, err
 	}
-	if did.IsURL() {
+	if !strings.HasPrefix(didURL.String(), "did:") {
+		return nil, ErrInvalidDID.wrap(errors.New("DID must start with 'did:'"))
+	}
+	if !didURL.urlEmpty() {
 		return nil, ErrInvalidDID.wrap(errors.New("DID can not have path, fragment or query params"))
 	}
-	return did, nil
-}
-
-// must accepts a function like Parse and returns the value without error or panics otherwise.
-func must(fn func(string) (*DID, error), input string) DID {
-	v, err := fn(input)
-	if err != nil {
-		panic(err)
-	}
-	return *v
+	return &didURL.DID, nil
 }
 
 // MustParseDID is like ParseDID but panics if the string cannot be parsed.
 // It simplifies safe initialization of global variables holding compiled UUIDs.
 func MustParseDID(input string) DID {
-	return must(ParseDID, input)
-}
-
-// MustParseDIDURL is like ParseDIDURL but panics if the string cannot be parsed.
-// It simplifies safe initialization of global variables holding compiled UUIDs.
-func MustParseDIDURL(input string) DID {
-	return must(ParseDIDURL, input)
+	result, err := ParseDID(input)
+	if err != nil {
+		panic(err)
+	}
+	return *result
 }
 
 // ErrInvalidDID is returned when a parser function is supplied with a string that can't be parsed as DID.

--- a/did/did_test.go
+++ b/did/did_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"github.com/stretchr/testify/require"
 	"io"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,8 +44,18 @@ func TestParseDID(t *testing.T) {
 		assert.Nil(t, id)
 		assert.ErrorIs(t, err, ErrInvalidDID)
 	})
-	t.Run("error - input is a DID URL", func(t *testing.T) {
-		id, err := ParseDID("did:nuts:123/path?query#fragment")
+	t.Run("error - is empty", func(t *testing.T) {
+		id, err := ParseDID("")
+		assert.Nil(t, id)
+		assert.EqualError(t, err, "invalid DID: DID must start with 'did:'")
+	})
+	t.Run("error - is a DID URL, without DID", func(t *testing.T) {
+		id, err := ParseDID("#fragment")
+		assert.Nil(t, id)
+		assert.EqualError(t, err, "invalid DID: DID must start with 'did:'")
+	})
+	t.Run("error - is a DID URL", func(t *testing.T) {
+		id, err := ParseDID("did:example:123/foo")
 		assert.Nil(t, id)
 		assert.EqualError(t, err, "invalid DID: DID can not have path, fragment or query params")
 	})
@@ -55,210 +64,6 @@ func TestParseDID(t *testing.T) {
 func TestMustParseDID(t *testing.T) {
 	assert.Panics(t, func() {
 		MustParseDID("did:nuts:123/path?query#fragment")
-	})
-}
-
-func TestParseDIDURL(t *testing.T) {
-	t.Run("parse a DID URL", func(t *testing.T) {
-		id, err := ParseDIDURL("did:nuts:123/path?query#fragment")
-		assert.Equal(t, "did:nuts:123/path?query=#fragment", id.String())
-		assert.NoError(t, err)
-	})
-	t.Run("with escaped ID", func(t *testing.T) {
-		id, err := ParseDIDURL("did:example:fizz%20buzz")
-		require.NoError(t, err)
-		assert.Equal(t, "did:example:fizz%20buzz", id.String())
-		assert.Equal(t, "fizz%20buzz", id.ID)
-		assert.Equal(t, "fizz buzz", id.DecodedID)
-	})
-	t.Run("with fragment", func(t *testing.T) {
-		id, err := ParseDIDURL("did:example:123#fragment")
-		require.NoError(t, err)
-		assert.Equal(t, "did:example:123#fragment", id.String())
-		assert.Equal(t, "fragment", id.Fragment)
-	})
-	t.Run("with escaped fragment", func(t *testing.T) {
-		id, err := ParseDIDURL("did:example:123#frag%20ment")
-		require.NoError(t, err)
-		assert.Equal(t, "did:example:123#frag%20ment", id.String())
-		assert.Equal(t, "frag%20ment", id.Fragment)
-		assert.Equal(t, "frag ment", id.DecodedFragment)
-	})
-	t.Run("with path", func(t *testing.T) {
-		id, err := ParseDIDURL("did:example:123/subpath")
-		require.NoError(t, err)
-		assert.Equal(t, "123", id.ID)
-		assert.Equal(t, "subpath", id.Path)
-	})
-	t.Run("escaped path", func(t *testing.T) {
-		id, err := ParseDIDURL("did:example:123/sub%20path")
-		require.NoError(t, err)
-		assert.Equal(t, "123", id.ID)
-		assert.Equal(t, "sub%20path", id.Path)
-		assert.Equal(t, "sub path", id.DecodedPath)
-	})
-	t.Run("empty path", func(t *testing.T) {
-		id, err := ParseDIDURL("did:example:123/")
-		require.NoError(t, err)
-		assert.Equal(t, "123", id.ID)
-		assert.Equal(t, "", id.Path)
-	})
-	t.Run("path and query", func(t *testing.T) {
-		id, err := ParseDIDURL("did:example:123/subpath?param=value")
-		require.NoError(t, err)
-		assert.Equal(t, "123", id.ID)
-		assert.Equal(t, "subpath", id.Path)
-		assert.Len(t, id.Query, 1)
-		assert.Equal(t, "value", id.Query.Get("param"))
-	})
-	t.Run("did:web", func(t *testing.T) {
-		t.Run("root without port", func(t *testing.T) {
-			id, err := ParseDID("did:web:example.com")
-			require.NoError(t, err)
-			assert.Equal(t, "did:web:example.com", id.String())
-		})
-		t.Run("root with port", func(t *testing.T) {
-			id, err := ParseDID("did:web:example.com%3A3000")
-			require.NoError(t, err)
-			assert.Equal(t, "did:web:example.com%3A3000", id.String())
-		})
-		t.Run("subpath", func(t *testing.T) {
-			id, err := ParseDID("did:web:example.com%3A3000:user:alice")
-			require.NoError(t, err)
-			assert.Equal(t, "did:web:example.com%3A3000:user:alice", id.String())
-			assert.Equal(t, "web", id.Method)
-			assert.Equal(t, "example.com%3A3000:user:alice", id.ID)
-		})
-		t.Run("subpath without port", func(t *testing.T) {
-			id, err := ParseDID("did:web:example.com:u:5")
-			require.NoError(t, err)
-			assert.Equal(t, "did:web:example.com:u:5", id.String())
-			assert.Equal(t, "web", id.Method)
-			assert.Equal(t, "example.com:u:5", id.ID)
-		})
-		t.Run("path, query and fragment", func(t *testing.T) {
-			id, err := ParseDIDURL("did:web:example.com%3A3000:user:alice/foo/bar?param=value#fragment")
-			require.NoError(t, err)
-			assert.Equal(t, "did:web:example.com%3A3000:user:alice/foo/bar?param=value#fragment", id.String())
-			assert.Equal(t, "web", id.Method)
-			assert.Equal(t, "example.com%3A3000:user:alice", id.ID)
-			assert.Equal(t, "foo/bar", id.Path)
-			assert.Len(t, id.Query, 1)
-			assert.Equal(t, "value", id.Query.Get("param"))
-			assert.Equal(t, "fragment", id.Fragment)
-		})
-	})
-
-	t.Run("ok - parsed DID URL equals constructed one", func(t *testing.T) {
-		parsed, err := ParseDIDURL("did:nuts:123/path?key=value#fragment")
-		require.NoError(t, err)
-		constructed := DID{
-			Method:      "nuts",
-			ID:          "123",
-			DecodedID:   "123",
-			Path:        "path",
-			DecodedPath: "path",
-			Query: url.Values{
-				"key": []string{"value"},
-			},
-			Fragment:        "fragment",
-			DecodedFragment: "fragment",
-		}
-		assert.Equal(t, constructed, *parsed)
-	})
-	t.Run("ok - parsed DID URL equals constructed one (no query)", func(t *testing.T) {
-		parsed, err := ParseDIDURL("did:nuts:123/path#fragment")
-		require.NoError(t, err)
-		constructed := DID{
-			Method:          "nuts",
-			ID:              "123",
-			DecodedID:       "123",
-			Path:            "path",
-			DecodedPath:     "path",
-			Fragment:        "fragment",
-			DecodedFragment: "fragment",
-		}
-		assert.Equal(t, constructed, *parsed)
-	})
-
-	t.Run("percent-encoded characters in ID are allowed", func(t *testing.T) {
-		parsed, err := ParseDIDURL("did:example:123%f8")
-		require.NoError(t, err)
-		constructed := DID{
-			Method:    "example",
-			ID:        "123%f8",
-			DecodedID: "123\xf8",
-		}
-		assert.Equal(t, constructed, *parsed)
-	})
-
-	t.Run("format validation", func(t *testing.T) {
-		type testCase struct {
-			name string
-			did  string
-		}
-		t.Run("valid DIDs", func(t *testing.T) {
-			testCases := []testCase{
-				{name: "basic DID", did: "did:example:123"},
-				{name: "with query", did: "did:example:123?foo=bar"},
-				{name: "with fragment", did: "did:example:123#foo"},
-				{name: "with path", did: "did:example:123/foo"},
-				{name: "with query, fragment and path", did: "did:example:123/foo?key=value#fragment"},
-				{name: "with semicolons", did: "did:example:123/foo?key=value#fragment"},
-			}
-			for _, tc := range testCases {
-				t.Run(tc.name, func(t *testing.T) {
-					id, err := ParseDIDURL(tc.did)
-					assert.NoError(t, err, "expected no error for DID: "+tc.did)
-					assert.Equal(t, tc.did, id.String())
-				})
-			}
-		})
-		t.Run("invalid DIDs", func(t *testing.T) {
-			testCases := []testCase{
-				{
-					name: "no method",
-					did:  "did:",
-				},
-				{
-					name: "does not begin with 'did:' prefix",
-					did:  "example:123",
-				},
-				{
-					name: "method contains invalid character",
-					did:  "did:example_:1234",
-				},
-				{
-					name: "ID is empty",
-					did:  "did:example:",
-				},
-				{
-					name: "ID is empty, with path",
-					did:  "did:example:/path",
-				},
-				{
-					name: "ID is empty, with fragment",
-					did:  "did:example:#fragment",
-				},
-				{
-					name: "ID contains invalid chars",
-					did:  "did:example:te@st",
-				},
-			}
-			for _, tc := range testCases {
-				t.Run(tc.name, func(t *testing.T) {
-					id, err := ParseDIDURL(tc.did)
-					assert.Error(t, err, "expected an error for DID: "+tc.did)
-					assert.Nil(t, id)
-				})
-			}
-		})
-	})
-}
-
-func TestMustParseDIDURL(t *testing.T) {
-	assert.Panics(t, func() {
-		MustParseDIDURL("invalidDID")
 	})
 }
 
@@ -271,71 +76,21 @@ func TestDID_MarshalText(t *testing.T) {
 }
 
 func TestDID_Equal(t *testing.T) {
-	t.Run("DID", func(t *testing.T) {
-		const did = "did:example:123"
-		t.Run("equal", func(t *testing.T) {
-			assert.True(t, MustParseDID(did).Equals(MustParseDID(did)))
-		})
-		t.Run("method differs", func(t *testing.T) {
-			assert.False(t, MustParseDID("did:example1:123").Equals(MustParseDID(did)))
-		})
-		t.Run("ID differs", func(t *testing.T) {
-			assert.False(t, MustParseDID("did:example:1234").Equals(MustParseDID(did)))
-		})
-		t.Run("one DID is empty", func(t *testing.T) {
-			assert.False(t, MustParseDID("did:example:1234").Equals(DID{}))
-		})
-		t.Run("both DIDs are empty", func(t *testing.T) {
-			assert.True(t, DID{}.Equals(DID{}))
-		})
-		t.Run("empty query (self)", func(t *testing.T) {
-			d1 := DID{
-				Method: "example",
-				ID:     "123",
-				Query:  nil,
-			}
-			d2 := DID{
-				Method: "example",
-				ID:     "123",
-				Query:  map[string][]string{},
-			}
-			assert.True(t, d1.Equals(d2))
-		})
-		t.Run("empty query (other)", func(t *testing.T) {
-			d1 := DID{
-				Method: "example",
-				ID:     "123",
-				Query:  map[string][]string{},
-			}
-			d2 := DID{
-				Method: "example",
-				ID:     "123",
-				Query:  nil,
-			}
-			assert.True(t, d1.Equals(d2))
-		})
+	const did = "did:example:123"
+	t.Run("equal", func(t *testing.T) {
+		assert.True(t, MustParseDID(did).Equals(MustParseDID(did)))
 	})
-	t.Run("DID URL", func(t *testing.T) {
-		t.Run("equal", func(t *testing.T) {
-			d1 := MustParseDIDURL("did:example:123/foo?key=value#fragment")
-			d2 := MustParseDIDURL("did:example:123/foo?key=value#fragment")
-			assert.True(t, d1.Equals(d2))
-		})
-		t.Run("fragment differs", func(t *testing.T) {
-			d1 := MustParseDIDURL("did:example:123/foo?key=value")
-			d2 := MustParseDIDURL("did:example:123/foo?key=value#fragment")
-			assert.False(t, d1.Equals(d2))
-		})
-		t.Run("query in different order", func(t *testing.T) {
-			d1 := MustParseDIDURL("did:example:123/foo?k1=a&k2=b")
-			d2 := MustParseDIDURL("did:example:123/foo?k2=b&k1=a")
-			assert.True(t, d1.Equals(d2))
-		})
-		t.Run("path differs", func(t *testing.T) {
-			d1 := MustParseDIDURL("did:example:123/fuzz?key=value#fragment")
-			d2 := MustParseDIDURL("did:example:123/fizz?key=value#fragment")
-			assert.False(t, d1.Equals(d2))
-		})
+	t.Run("method differs", func(t *testing.T) {
+		assert.False(t, MustParseDID("did:example1:123").Equals(MustParseDID(did)))
+	})
+	t.Run("ID differs", func(t *testing.T) {
+		assert.False(t, MustParseDID("did:example:1234").Equals(MustParseDID(did)))
+	})
+	t.Run("one DID is empty", func(t *testing.T) {
+		assert.False(t, MustParseDID("did:example:1234").Equals(DID{}))
+	})
+	t.Run("both DIDs are empty", func(t *testing.T) {
+		assert.True(t, DID{}.Equals(DID{}))
 	})
 }
 
@@ -359,62 +114,6 @@ func TestDID_String(t *testing.T) {
 			expected: "",
 			did:      DID{},
 		},
-		{
-			name:     "with path",
-			expected: "did:example:123/foo",
-			did: DID{
-				Method: "example",
-				ID:     "123",
-				Path:   "foo",
-			},
-		},
-		{
-			name:     "with escapable characters in path",
-			expected: "did:example:123/fizz%20buzz",
-			did: DID{
-				Method: "example",
-				ID:     "123",
-				Path:   "fizz%20buzz",
-			},
-		},
-		{
-			name:     "with fragment",
-			expected: "did:example:123#fragment",
-			did: DID{
-				Method:   "example",
-				ID:       "123",
-				Fragment: "fragment",
-			},
-		},
-		{
-			name:     "with escapable characters in fragment",
-			expected: "did:example:123#fizz%20buzz",
-			did: DID{
-				Method:   "example",
-				ID:       "123",
-				Fragment: "fizz%20buzz",
-			},
-		},
-		{
-			name:     "with query",
-			expected: "did:example:123?key=value",
-			did: DID{
-				Method: "example",
-				ID:     "123",
-				Query:  url.Values{"key": []string{"value"}},
-			},
-		},
-		{
-			name:     "with everything",
-			expected: "did:example:123/foo?key=value#fragment",
-			did: DID{
-				Method:   "example",
-				ID:       "123",
-				Path:     "foo",
-				Fragment: "fragment",
-				Query:    url.Values{"key": []string{"value"}},
-			},
-		},
 	}
 
 	for _, tc := range testCases {
@@ -425,15 +124,9 @@ func TestDID_String(t *testing.T) {
 }
 
 func TestDID_Empty(t *testing.T) {
-	t.Run("not empty for filled did", func(t *testing.T) {
-		id, err := ParseDID("did:nuts:123")
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-			return
-		}
-		assert.False(t, id.Empty())
+	t.Run("DID", func(t *testing.T) {
+		assert.False(t, MustParseDID("did:nuts:123").Empty())
 	})
-
 	t.Run("empty when just generated", func(t *testing.T) {
 		id := DID{}
 		assert.True(t, id.Empty())
@@ -457,19 +150,4 @@ func TestError(t *testing.T) {
 	assert.True(t, errors.Is(actual, ErrInvalidDID))
 	assert.True(t, errors.Is(actual, io.EOF))
 	assert.False(t, errors.Is(actual, io.ErrShortBuffer))
-}
-
-func TestDID_WithoutURL(t *testing.T) {
-	t.Run("with encoded ID", func(t *testing.T) {
-		id := MustParseDIDURL("did:example:123%20/path?key=value#fragment").WithoutURL()
-		assert.Equal(t, "did:example:123%20", id.String())
-		assert.Equal(t, "123 ", id.DecodedID)
-		assert.Empty(t, id.Path)
-		assert.Empty(t, id.Fragment)
-		assert.Empty(t, id.Query)
-	})
-	t.Run("equalness", func(t *testing.T) {
-		id := MustParseDIDURL("did:example:123/path?key=value#fragment").WithoutURL()
-		assert.True(t, MustParseDID("did:example:123").Equals(id))
-	})
 }

--- a/did/didurl.go
+++ b/did/didurl.go
@@ -1,0 +1,163 @@
+package did
+
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"github.com/nuts-foundation/go-did"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var _ fmt.Stringer = DIDURL{}
+var _ encoding.TextMarshaler = DIDURL{}
+
+var didURLPattern = regexp.MustCompile(`^(did:([a-z0-9]+):((?:(?:[a-zA-Z0-9.\-_:])+|(?:%[0-9a-fA-F]{2})+)+)|)(/.*?|)(\?.*?|)(#.*|)$`)
+
+type DIDURL struct {
+	DID
+
+	// Path is the DID path without the leading '/', in escaped form.
+	Path string
+	// DecodedPath is the DID path without the leading '/', in unescaped form.
+	// It is only set during parsing, and not used by the String() method.
+	DecodedPath string
+	// Query contains the DID query key-value pairs, in unescaped form.
+	// String() will escape the values again, and order the keys alphabetically.
+	Query url.Values
+
+	// Fragment is the DID fragment without the leading '#', in escaped form.
+	Fragment string
+	// DecodedFragment is the DID fragment without the leading '#', in unescaped form.
+	// It is only set during parsing, and not used by the String() method.
+	DecodedFragment string
+}
+
+// Equals checks whether the DIDURL equals to another DIDURL.
+// The check is case-sensitive.
+func (d DIDURL) Equals(other DIDURL) bool {
+	return d.cleanup().String() == other.cleanup().String()
+}
+
+// UnmarshalJSON unmarshals a DID URL encoded as JSON string, e.g.:
+// "did:nuts:c0dc584345da8a0e1e7a584aa4a36c30ebdb79d907aff96fe0e90ee972f58a17#key-1"
+func (d *DIDURL) UnmarshalJSON(bytes []byte) error {
+	var didString string
+	err := json.Unmarshal(bytes, &didString)
+	if err != nil {
+		return ErrInvalidDID.wrap(err)
+	}
+	tmp, err := ParseDIDURL(didString)
+	if err != nil {
+		return err
+	}
+	*d = *tmp
+	return nil
+}
+
+// MarshalJSON marshals the DIDURL to a JSON string
+func (d DIDURL) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+// Empty checks whether the DID is set or not
+func (d DIDURL) Empty() bool {
+	return d.DID.Empty() && d.urlEmpty()
+}
+
+// urlEmpty checks whether the URL part of the DID URL is set or not (path, fragment, or query).
+func (d DIDURL) urlEmpty() bool {
+	return d.Path == "" && d.Fragment == "" && len(d.Query) == 0
+}
+
+// String returns the DID as formatted string.
+func (d DIDURL) String() string {
+	if d.Empty() {
+		return ""
+	}
+	result := d.DID.String()
+	if d.Path != "" {
+		result += "/" + d.Path
+	}
+	if len(d.Query) > 0 {
+		result += "?" + d.Query.Encode()
+	}
+	if d.Fragment != "" {
+		result += "#" + d.Fragment
+	}
+	return result
+}
+
+func (d DIDURL) cleanup() DIDURL {
+	if len(d.Query) == 0 {
+		d.Query = nil
+	}
+	return d
+}
+
+// URI converts the DIDURL to a URI.
+// URIs are used in Verifiable Credentials
+func (d DIDURL) URI() ssi.URI {
+	result := d.DID.URI()
+	result.RawFragment = d.Fragment
+	result.RawPath = d.Path
+	result.RawQuery = d.Query.Encode()
+	return result
+}
+
+// ParseDIDURL parses a DID URL.
+// https://www.w3.org/TR/did-core/#did-url-syntax
+// A DID URL is a URL that builds on the DID scheme.
+func ParseDIDURL(input string) (*DIDURL, error) {
+	// There are 6 submatches (base 0)
+	// 0. DID + path + query + fragment
+	// 1. DID
+	// 2. method
+	// 3. id
+	// 4. path (starting with '/')
+	// 5. query (starting with '?')
+	// 6. fragment (starting with '#')
+	matches := didURLPattern.FindStringSubmatch(input)
+	if len(matches) == 0 {
+		return nil, ErrInvalidDID
+	}
+
+	result := DIDURL{
+		DID: DID{
+			Method: matches[2],
+			ID:     matches[3],
+		},
+		Path:     strings.TrimPrefix(matches[4], "/"),
+		Fragment: strings.TrimPrefix(matches[6], "#"),
+	}
+	var err error
+	result.DecodedID, err = url.PathUnescape(result.ID)
+	if err != nil {
+		return nil, ErrInvalidDID.wrap(fmt.Errorf("invalid ID: %w", err))
+	}
+	result.DecodedPath, err = url.PathUnescape(result.Path)
+	if err != nil {
+		return nil, ErrInvalidDID.wrap(fmt.Errorf("invalid path: %w", err))
+	}
+	result.DecodedFragment, err = url.PathUnescape(result.Fragment)
+	if err != nil {
+		return nil, ErrInvalidDID.wrap(fmt.Errorf("invalid fragment: %w", err))
+	}
+	result.Query, err = url.ParseQuery(strings.TrimPrefix(matches[5], "?"))
+	if err != nil {
+		return nil, ErrInvalidDID.wrap(err)
+	}
+	result = result.cleanup()
+	return &result, nil
+}
+
+// MustParseDIDURL is like ParseDIDURL but panics if the string cannot be parsed.
+// It simplifies safe initialization of global variables holding compiled UUIDs.
+func MustParseDIDURL(input string) DIDURL {
+	result, err := ParseDIDURL(input)
+	if err != nil {
+		panic(err)
+	}
+	return *result
+}

--- a/did/didurl.go
+++ b/did/didurl.go
@@ -99,10 +99,18 @@ func (d DIDURL) cleanup() DIDURL {
 // URI converts the DIDURL to a URI.
 // URIs are used in Verifiable Credentials
 func (d DIDURL) URI() ssi.URI {
-	result := d.DID.URI()
+	var result ssi.URI
+	if !d.DID.Empty() {
+		result = d.DID.URI()
+	}
+	if d.Path != "" {
+		result.Opaque += "/" + d.Path
+	}
+	if len(d.Query) != 0 {
+		result.Opaque += "?" + d.Query.Encode()
+	}
+	result.Fragment = d.DecodedFragment
 	result.RawFragment = d.Fragment
-	result.RawPath = d.Path
-	result.RawQuery = d.Query.Encode()
 	return result
 }
 

--- a/did/didurl.go
+++ b/did/didurl.go
@@ -26,7 +26,6 @@ type DIDURL struct {
 	// Query contains the DID query key-value pairs, in unescaped form.
 	// String() will escape the values again, and order the keys alphabetically.
 	Query url.Values
-
 	// Fragment is the DID fragment without the leading '#', in escaped form.
 	Fragment string
 	// DecodedFragment is the DID fragment without the leading '#', in unescaped form.
@@ -109,8 +108,7 @@ func (d DIDURL) URI() ssi.URI {
 	if len(d.Query) != 0 {
 		result.Opaque += "?" + d.Query.Encode()
 	}
-	result.Fragment = d.DecodedFragment
-	result.RawFragment = d.Fragment
+	result.Fragment = d.Fragment
 	return result
 }
 

--- a/did/didurl_test.go
+++ b/did/didurl_test.go
@@ -1,0 +1,409 @@
+package did
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDIDURL_UnmarshalJSON(t *testing.T) {
+	const input = `"did:example:123"`
+	id := DIDURL{}
+	err := json.Unmarshal([]byte(input), &id)
+	require.NoError(t, err)
+	assert.Equal(t, "did:example:123", id.String())
+}
+
+func TestDIDURL_MarshalJSON(t *testing.T) {
+	actual, err := json.Marshal(MustParseDIDURL("did:example:123"))
+	require.NoError(t, err)
+	assert.Equal(t, `"did:example:123"`, string(actual))
+}
+
+func TestParseDIDURL(t *testing.T) {
+	t.Run("parse a DID URL", func(t *testing.T) {
+		id, err := ParseDIDURL("did:example:123/path?query#fragment")
+		assert.Equal(t, "did:example:123/path?query=#fragment", id.String())
+		assert.NoError(t, err)
+	})
+	t.Run("with escaped ID", func(t *testing.T) {
+		id, err := ParseDIDURL("did:example:fizz%20buzz")
+		require.NoError(t, err)
+		assert.Equal(t, "did:example:fizz%20buzz", id.String())
+		assert.Equal(t, "fizz%20buzz", id.ID)
+		assert.Equal(t, "fizz buzz", id.DecodedID)
+	})
+	t.Run("with fragment", func(t *testing.T) {
+		id, err := ParseDIDURL("did:example:123#fragment")
+		require.NoError(t, err)
+		assert.Equal(t, "did:example:123#fragment", id.String())
+		assert.Equal(t, "fragment", id.Fragment)
+	})
+	t.Run("with escaped fragment", func(t *testing.T) {
+		id, err := ParseDIDURL("did:example:123#frag%20ment")
+		require.NoError(t, err)
+		assert.Equal(t, "did:example:123#frag%20ment", id.String())
+		assert.Equal(t, "frag%20ment", id.Fragment)
+		assert.Equal(t, "frag ment", id.DecodedFragment)
+	})
+	t.Run("with path", func(t *testing.T) {
+		id, err := ParseDIDURL("did:example:123/subpath")
+		require.NoError(t, err)
+		assert.Equal(t, "123", id.ID)
+		assert.Equal(t, "subpath", id.Path)
+	})
+	t.Run("escaped path", func(t *testing.T) {
+		id, err := ParseDIDURL("did:example:123/sub%20path")
+		require.NoError(t, err)
+		assert.Equal(t, "123", id.ID)
+		assert.Equal(t, "sub%20path", id.Path)
+		assert.Equal(t, "sub path", id.DecodedPath)
+	})
+	t.Run("empty path", func(t *testing.T) {
+		id, err := ParseDIDURL("did:example:123/")
+		require.NoError(t, err)
+		assert.Equal(t, "123", id.ID)
+		assert.Equal(t, "", id.Path)
+	})
+	t.Run("path and query", func(t *testing.T) {
+		id, err := ParseDIDURL("did:example:123/subpath?param=value")
+		require.NoError(t, err)
+		assert.Equal(t, "123", id.ID)
+		assert.Equal(t, "subpath", id.Path)
+		assert.Len(t, id.Query, 1)
+		assert.Equal(t, "value", id.Query.Get("param"))
+	})
+	t.Run("did:web", func(t *testing.T) {
+		t.Run("root without port", func(t *testing.T) {
+			id, err := ParseDID("did:web:example.com")
+			require.NoError(t, err)
+			assert.Equal(t, "did:web:example.com", id.String())
+		})
+		t.Run("root with port", func(t *testing.T) {
+			id, err := ParseDID("did:web:example.com%3A3000")
+			require.NoError(t, err)
+			assert.Equal(t, "did:web:example.com%3A3000", id.String())
+		})
+		t.Run("subpath", func(t *testing.T) {
+			id, err := ParseDID("did:web:example.com%3A3000:user:alice")
+			require.NoError(t, err)
+			assert.Equal(t, "did:web:example.com%3A3000:user:alice", id.String())
+			assert.Equal(t, "web", id.Method)
+			assert.Equal(t, "example.com%3A3000:user:alice", id.ID)
+		})
+		t.Run("subpath without port", func(t *testing.T) {
+			id, err := ParseDID("did:web:example.com:u:5")
+			require.NoError(t, err)
+			assert.Equal(t, "did:web:example.com:u:5", id.String())
+			assert.Equal(t, "web", id.Method)
+			assert.Equal(t, "example.com:u:5", id.ID)
+		})
+		t.Run("path, query and fragment", func(t *testing.T) {
+			id, err := ParseDIDURL("did:web:example.com%3A3000:user:alice/foo/bar?param=value#fragment")
+			require.NoError(t, err)
+			assert.Equal(t, "did:web:example.com%3A3000:user:alice/foo/bar?param=value#fragment", id.String())
+			assert.Equal(t, "web", id.Method)
+			assert.Equal(t, "example.com%3A3000:user:alice", id.ID)
+			assert.Equal(t, "foo/bar", id.Path)
+			assert.Len(t, id.Query, 1)
+			assert.Equal(t, "value", id.Query.Get("param"))
+			assert.Equal(t, "fragment", id.Fragment)
+		})
+	})
+
+	t.Run("ok - parsed DID URL equals constructed one", func(t *testing.T) {
+		parsed, err := ParseDIDURL("did:example:123/path?key=value#fragment")
+		require.NoError(t, err)
+		constructed := DIDURL{
+			DID: DID{
+				Method:    "example",
+				ID:        "123",
+				DecodedID: "123",
+			},
+			Path:        "path",
+			DecodedPath: "path",
+			Query: url.Values{
+				"key": []string{"value"},
+			},
+			Fragment:        "fragment",
+			DecodedFragment: "fragment",
+		}
+		assert.Equal(t, constructed, *parsed)
+	})
+	t.Run("ok - parsed DID URL equals constructed one (no query)", func(t *testing.T) {
+		parsed, err := ParseDIDURL("did:example:123/path#fragment")
+		require.NoError(t, err)
+		constructed := DIDURL{
+			DID: DID{
+				Method:    "example",
+				ID:        "123",
+				DecodedID: "123",
+			},
+			Path:            "path",
+			DecodedPath:     "path",
+			Fragment:        "fragment",
+			DecodedFragment: "fragment",
+		}
+		assert.Equal(t, constructed, *parsed)
+	})
+
+	t.Run("percent-encoded characters in ID are allowed", func(t *testing.T) {
+		parsed, err := ParseDIDURL("did:example:123%f8")
+		require.NoError(t, err)
+		constructed := DIDURL{
+			DID: DID{
+				Method:    "example",
+				ID:        "123%f8",
+				DecodedID: "123\xf8",
+			},
+		}
+		assert.Equal(t, constructed, *parsed)
+	})
+
+	t.Run("format validation", func(t *testing.T) {
+		type testCase struct {
+			name string
+			did  string
+		}
+		t.Run("valid DIDs", func(t *testing.T) {
+			testCases := []testCase{
+				{name: "basic DID", did: "did:example:123"},
+				{name: "with query", did: "did:example:123?foo=bar"},
+				{name: "with fragment", did: "did:example:123#foo"},
+				{name: "with path", did: "did:example:123/foo"},
+				{name: "with query, fragment and path", did: "did:example:123/foo?key=value#fragment"},
+				{name: "with semicolons", did: "did:example:123/foo?key=value#fragment"},
+				{name: "only fragment", did: "#fragment"},
+				{name: "only query", did: "?key=value"},
+				{name: "only query and fragment", did: "?key=value#fragment"},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					id, err := ParseDIDURL(tc.did)
+					assert.NoError(t, err, "expected no error for DID: "+tc.did)
+					assert.Equal(t, tc.did, id.String())
+				})
+			}
+		})
+		t.Run("invalid DIDs", func(t *testing.T) {
+			testCases := []testCase{
+				{
+					name: "no method",
+					did:  "did:",
+				},
+				{
+					name: "does not begin with 'did:' prefix",
+					did:  "example:123",
+				},
+				{
+					name: "method contains invalid character",
+					did:  "did:example_:1234",
+				},
+				{
+					name: "ID is empty",
+					did:  "did:example:",
+				},
+				{
+					name: "ID is empty, with path",
+					did:  "did:example:/path",
+				},
+				{
+					name: "ID is empty, with fragment",
+					did:  "did:example:#fragment",
+				},
+				{
+					name: "ID contains invalid chars",
+					did:  "did:example:te@st",
+				},
+			}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					id, err := ParseDIDURL(tc.did)
+					assert.Error(t, err, "expected an error for DID: "+tc.did)
+					assert.Nil(t, id)
+				})
+			}
+		})
+	})
+}
+
+func TestMustParseDIDURL(t *testing.T) {
+	assert.Panics(t, func() {
+		MustParseDIDURL("invalidDID")
+	})
+}
+
+func TestDIDURL_MarshalText(t *testing.T) {
+	const expected = "did:example:123"
+	id := MustParseDIDURL(expected)
+	actual, err := id.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(expected), actual)
+}
+
+func TestDIDURL_Equal(t *testing.T) {
+	t.Run("equal", func(t *testing.T) {
+		d1 := MustParseDIDURL("did:example:123/foo?key=value#fragment")
+		d2 := MustParseDIDURL("did:example:123/foo?key=value#fragment")
+		assert.True(t, d1.Equals(d2))
+	})
+	t.Run("method differs", func(t *testing.T) {
+		assert.False(t, MustParseDIDURL("did:example1:123").Equals(MustParseDIDURL("did:example:123")))
+	})
+	t.Run("ID differs", func(t *testing.T) {
+		assert.False(t, MustParseDIDURL("did:example:1234").Equals(MustParseDIDURL("did:example:123")))
+	})
+	t.Run("one DID is empty", func(t *testing.T) {
+		assert.False(t, MustParseDIDURL("did:example:1234").Equals(DIDURL{}))
+	})
+	t.Run("both DIDs are empty", func(t *testing.T) {
+		assert.True(t, DIDURL{}.Equals(DIDURL{}))
+	})
+	t.Run("fragment differs", func(t *testing.T) {
+		d1 := MustParseDIDURL("did:example:123/foo?key=value")
+		d2 := MustParseDIDURL("did:example:123/foo?key=value#fragment")
+		assert.False(t, d1.Equals(d2))
+	})
+	t.Run("query in different order", func(t *testing.T) {
+		d1 := MustParseDIDURL("did:example:123/foo?k1=a&k2=b")
+		d2 := MustParseDIDURL("did:example:123/foo?k2=b&k1=a")
+		assert.True(t, d1.Equals(d2))
+	})
+	t.Run("empty query (self)", func(t *testing.T) {
+		d1 := MustParseDIDURL("did:example:123/foo")
+		d2 := MustParseDIDURL("did:example:123/foo?")
+		assert.True(t, d1.Equals(d2))
+	})
+	t.Run("empty query (self)", func(t *testing.T) {
+		d1 := MustParseDIDURL("did:example:123/foo?")
+		d2 := MustParseDIDURL("did:example:123/foo")
+		assert.True(t, d1.Equals(d2))
+	})
+	t.Run("path differs", func(t *testing.T) {
+		d1 := MustParseDIDURL("did:example:123/fuzz?key=value#fragment")
+		d2 := MustParseDIDURL("did:example:123/fizz?key=value#fragment")
+		assert.False(t, d1.Equals(d2))
+	})
+}
+
+func TestDIDURL_String(t *testing.T) {
+	type testCase struct {
+		name     string
+		expected string
+		did      DIDURL
+	}
+	testCases := []testCase{
+		{
+			name:     "basic DID",
+			expected: "did:example:123",
+			did: DIDURL{
+				DID: DID{
+					Method: "example",
+					ID:     "123",
+				},
+			},
+		},
+		{
+			name:     "empty DID",
+			expected: "",
+			did:      DIDURL{},
+		},
+		{
+			name:     "with path",
+			expected: "did:example:123/foo",
+			did: DIDURL{
+				DID: DID{
+					Method: "example",
+					ID:     "123",
+				},
+				Path: "foo",
+			},
+		},
+		{
+			name:     "with escapable characters in path",
+			expected: "did:example:123/fizz%20buzz",
+			did: DIDURL{
+				DID: DID{
+					Method: "example",
+					ID:     "123",
+				},
+				Path: "fizz%20buzz",
+			},
+		},
+		{
+			name:     "with fragment",
+			expected: "did:example:123#fragment",
+			did: DIDURL{
+				DID: DID{
+					Method: "example",
+					ID:     "123",
+				},
+				Fragment: "fragment",
+			},
+		},
+		{
+			name:     "with escapable characters in fragment",
+			expected: "did:example:123#fizz%20buzz",
+			did: DIDURL{
+				DID: DID{
+					Method: "example",
+					ID:     "123",
+				},
+				Fragment: "fizz%20buzz",
+			},
+		},
+		{
+			name:     "with query",
+			expected: "did:example:123?key=value",
+			did: DIDURL{
+				DID: DID{
+					Method: "example",
+					ID:     "123",
+				},
+				Query: url.Values{"key": []string{"value"}},
+			},
+		},
+		{
+			name:     "with everything",
+			expected: "did:example:123/foo?key=value#fragment",
+			did: DIDURL{
+				DID: DID{
+					Method: "example",
+					ID:     "123",
+				},
+				Path:     "foo",
+				Fragment: "fragment",
+				Query:    url.Values{"key": []string{"value"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.did.String())
+		})
+	}
+}
+
+func TestDIDURL_Empty(t *testing.T) {
+	t.Run("DID", func(t *testing.T) {
+		assert.False(t, MustParseDIDURL("did:example:123").Empty())
+	})
+	t.Run("DID URL", func(t *testing.T) {
+		assert.False(t, MustParseDIDURL("#fragment").Empty())
+	})
+	t.Run("empty when just generated", func(t *testing.T) {
+		id := DIDURL{}
+		assert.True(t, id.Empty())
+	})
+}
+
+func TestDIDURL_URI(t *testing.T) {
+	id, err := ParseDIDURL("did:example:123")
+	require.NoError(t, err)
+	uri := id.URI()
+	assert.Equal(t, id.String(), uri.String())
+}

--- a/did/didurl_test.go
+++ b/did/didurl_test.go
@@ -447,10 +447,6 @@ func TestDIDURL_URI(t *testing.T) {
 			name:     "with escaped path",
 			expected: "/foo%20bar?key=value#fragment",
 		},
-		{
-			name:     "with escaped fragment",
-			expected: "/foo?key=value#frag%20ment",
-		},
 	}
 
 	for _, tc := range testCases {

--- a/did/didurl_test.go
+++ b/did/didurl_test.go
@@ -402,8 +402,61 @@ func TestDIDURL_Empty(t *testing.T) {
 }
 
 func TestDIDURL_URI(t *testing.T) {
-	id, err := ParseDIDURL("did:example:123")
-	require.NoError(t, err)
-	uri := id.URI()
-	assert.Equal(t, id.String(), uri.String())
+	type testCase struct {
+		name     string
+		expected string
+	}
+	testCases := []testCase{
+		{
+			name:     "just DID",
+			expected: "did:example:123",
+		},
+		{
+			name:     "with path",
+			expected: "did:example:123/foo",
+		},
+		{
+			name:     "with query",
+			expected: "did:example:123?key=value",
+		},
+		{
+			name:     "with fragment",
+			expected: "did:example:123#fragment",
+		},
+		{
+			name:     "with everything",
+			expected: "did:example:123/foo?key=value#fragment",
+		},
+		{
+			name:     "without DID",
+			expected: "/foo?key=value#fragment",
+		},
+		{
+			name:     "just fragment",
+			expected: "#fragment",
+		},
+		{
+			name:     "just query",
+			expected: "?key=value",
+		},
+		{
+			name:     "just path",
+			expected: "/foo",
+		},
+		{
+			name:     "with escaped path",
+			expected: "/foo%20bar?key=value#fragment",
+		},
+		{
+			name:     "with escaped fragment",
+			expected: "/foo?key=value#frag%20ment",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			id := MustParseDIDURL(tc.expected)
+			assert.Equal(t, tc.expected, id.URI().String())
+		})
+	}
 }

--- a/did/validator.go
+++ b/did/validator.go
@@ -111,12 +111,12 @@ func (w baseValidator) Validate(document Document) error {
 		return makeValidationError(ErrInvalidContext)
 	}
 	// Verify `id`
-	if document.ID.Empty() || document.ID.IsURL() {
+	if document.ID.Empty() {
 		return makeValidationError(ErrInvalidID)
 	}
 	// Verify `controller`
 	for _, controller := range document.Controller {
-		if controller.Empty() || controller.IsURL() {
+		if controller.Empty() {
 			return makeValidationError(ErrInvalidController)
 		}
 	}


### PR DESCRIPTION
Implements https://www.w3.org/TR/did-core/#relative-did-urls

Verification method IDs can be relative to their document DID. The same applies to relationships.

It also applies to service IDs, but those are URIs (rather than DID URLs), so those already parsed correctly (and we don't do any resolving on the IDs in this library).

Required for supporting SIOPv2/OpenID4VP flow with Microsoft Authenticator