### PR TITLE
Support JSON-LD graph in document @context

### DIFF
--- a/did/document.go
+++ b/did/document.go
@@ -51,7 +51,7 @@ func ParseDocument(raw string) (*Document, error) {
 
 // Document represents a DID Document as specified by the DID Core specification (https://www.w3.org/TR/did-core/).
 type Document struct {
-	Context              []ssi.URI                 `json:"@context"`
+	Context              []interface{}             `json:"@context"`
 	ID                   DID                       `json:"id"`
 	Controller           []DID                     `json:"controller,omitempty"`
 	AlsoKnownAs          []ssi.URI                 `json:"alsoKnownAs,omitempty"`

--- a/did/document_test.go
+++ b/did/document_test.go
@@ -55,8 +55,8 @@ func Test_Document(t *testing.T) {
 			return
 		}
 		expected := "https://www.w3.org/ns/did/v1"
-		if expected != actual.Context[0].String() {
-			t.Errorf("expected:\n%s\n, got:\n%s", expected, actual.Context[0].String())
+		if expected != actual.Context[0].(string) {
+			t.Errorf("expected:\n%s\n, got:\n%s", expected, actual.Context[0].(string))
 		}
 	})
 	t.Run("validate controllers", func(t *testing.T) {

--- a/did/validator_test.go
+++ b/did/validator_test.go
@@ -21,7 +21,12 @@ func TestW3CSpecValidator(t *testing.T) {
 		}
 		t.Run("context is missing DIDv1", func(t *testing.T) {
 			input := document()
-			input.Context = []ssi.URI{}
+			input.Context = []interface{}{
+				"someting-else",
+				map[string]interface{}{
+					"@base": "did:example:123",
+				},
+			}
 			assertIsError(t, ErrInvalidContext, W3CSpecValidator{}.Validate(input))
 		})
 		t.Run("invalid ID - is empty", func(t *testing.T) {
@@ -169,7 +174,12 @@ func document() Document {
 	serviceID := *did
 	serviceID.Fragment = "service-1"
 	doc := Document{
-		Context:            []ssi.URI{DIDContextV1URI()},
+		Context: []interface{}{
+			DIDContextV1URI(),
+			map[string]interface{}{
+				"@base": "did:example:12345",
+			},
+		},
 		ID:                 *did,
 		Controller:         []DID{*did},
 		VerificationMethod: []*VerificationMethod{vm},


### PR DESCRIPTION
For JSON-LD documents, `@context` can contain a graph (object).