### PR TITLE
Remove CircleCI badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 
 # github.com/nuts-foundation/go-did
-[![GoDID](https://circleci.com/gh/nuts-foundation/go-did.svg?style=svg)](https://circleci.com/gh/nuts-foundation/go-did) 
 [![Go Reference](https://pkg.go.dev/badge/github.com/nuts-foundation/go-did.svg)](https://pkg.go.dev/github.com/nuts-foundation/go-did)
 [![Maintainability](https://api.codeclimate.com/v1/badges/4b4c812605d5c4f5ba3f/maintainability)](https://codeclimate.com/github/nuts-foundation/go-did/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/4b4c812605d5c4f5ba3f/test_coverage)](https://codeclimate.com/github/nuts-foundation/go-did/test_coverage)


### PR DESCRIPTION
the config.yaml has been removed, so this always fails

probably also need to stop building the repo on https://circleci.com/gh/nuts-foundation/go-did 