### PR TITLE
Add UnmarshalCredentialStatus

### DIFF
--- a/vc/json.go
+++ b/vc/json.go
@@ -8,6 +8,7 @@ const (
 	contextKey              = "@context"
 	typeKey                 = "type"
 	credentialSubjectKey    = "credentialSubject"
+	credentialStatusKey     = "credentialStatus"
 	proofKey                = "proof"
 	verifiableCredentialKey = "verifiableCredential"
 )

--- a/vc/vc.go
+++ b/vc/vc.go
@@ -142,7 +142,7 @@ type VerifiableCredential struct {
 	IssuanceDate time.Time `json:"issuanceDate"`
 	// ExpirationDate is a rfc3339 formatted datetime. It is optional
 	ExpirationDate *time.Time `json:"expirationDate,omitempty"`
-	// CredentialStatus holds information on how the credential can be revoked. It is optional
+	// CredentialStatus holds information on how the credential can be revoked. It must be extracted using the UnmarshalCredentialStatus method and a custom type. It is optional
 	CredentialStatus *CredentialStatus `json:"credentialStatus,omitempty"`
 	// CredentialSubject holds the actual data for the credential. It must be extracted using the UnmarshalCredentialSubject method and a custom type.
 	CredentialSubject []interface{} `json:"credentialSubject"`
@@ -243,6 +243,16 @@ func (vc VerifiableCredential) UnmarshalCredentialSubject(target interface{}) er
 	} else {
 		return json.Unmarshal(asJSON, target)
 	}
+}
+
+// UnmarshalCredentialStatus unmarshalls the credentialStatus field to the provided target.
+func (vc VerifiableCredential) UnmarshalCredentialStatus(target any) error {
+	type VC struct {
+		Target any `json:"credentialStatus"`
+	}
+
+	cs := VC{Target: target}
+	return json.Unmarshal([]byte(vc.Raw()), &cs)
 }
 
 // SubjectDID returns the credential subject's ID as DID (credentialSubject.id).

--- a/vc/vc.go
+++ b/vc/vc.go
@@ -1,6 +1,7 @@
 package vc
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -113,7 +114,7 @@ func parseJWTCredential(raw string) (*VerifiableCredential, error) {
 
 func parseJSONLDCredential(raw string) (*VerifiableCredential, error) {
 	type Alias VerifiableCredential
-	normalizedVC, err := marshal.NormalizeDocument([]byte(raw), pluralContext, marshal.Plural(typeKey), marshal.Plural(credentialSubjectKey), marshal.Plural(proofKey))
+	normalizedVC, err := marshal.NormalizeDocument([]byte(raw), pluralContext, marshal.Plural(typeKey), marshal.Plural(credentialSubjectKey), marshal.Plural(credentialStatusKey), marshal.Plural(proofKey))
 	if err != nil {
 		return nil, err
 	}
@@ -142,8 +143,8 @@ type VerifiableCredential struct {
 	IssuanceDate time.Time `json:"issuanceDate"`
 	// ExpirationDate is a rfc3339 formatted datetime. It is optional
 	ExpirationDate *time.Time `json:"expirationDate,omitempty"`
-	// CredentialStatus holds information on how the credential can be revoked. It must be extracted using the UnmarshalCredentialStatus method and a custom type. It is optional
-	CredentialStatus *CredentialStatus `json:"credentialStatus,omitempty"`
+	// CredentialStatus holds information on how the credential can be revoked. It must be extracted using the UnmarshalCredentialStatus method and a custom type.
+	CredentialStatus []any `json:"credentialStatus,omitempty"`
 	// CredentialSubject holds the actual data for the credential. It must be extracted using the UnmarshalCredentialSubject method and a custom type.
 	CredentialSubject []interface{} `json:"credentialSubject"`
 	// Proof contains the cryptographic proof(s). It must be extracted using the Proofs method or UnmarshalProofValue method for non-generic proof fields.
@@ -173,10 +174,49 @@ func (vc VerifiableCredential) JWT() jwt.Token {
 	return token
 }
 
-// CredentialStatus defines the method on how to determine a credential is revoked.
+// CredentialStatus contains the required fields ID and Type, and the raw data for unmarshalling into a custom type.
 type CredentialStatus struct {
 	ID   ssi.URI `json:"id"`
 	Type string  `json:"type"`
+	raw  []byte
+}
+
+func (cs *CredentialStatus) UnmarshalJSON(input []byte) error {
+	type alias *CredentialStatus
+	a := alias(cs)
+	err := json.Unmarshal(input, a)
+	if err != nil {
+		return err
+	}
+
+	// keep compacted copy of the input
+	buf := new(bytes.Buffer)
+	if err = json.Compact(buf, input); err != nil {
+		// should never happen, already parsed as valid json
+		return err
+	}
+	cs.raw = buf.Bytes()
+	return nil
+}
+
+// Raw returns a copy of the underlying credentialStatus data as set during UnmarshalJSON.
+// This can be used to marshal the data into a custom status credential type.
+func (cs *CredentialStatus) Raw() []byte {
+	if cs.raw == nil {
+		return nil
+	}
+	cp := make([]byte, len(cs.raw))
+	copy(cp, cs.raw)
+	return cp
+}
+
+// CredentialStatuses returns VerifiableCredential.CredentialStatus marshalled into a CredentialStatus slice.
+func (vc VerifiableCredential) CredentialStatuses() ([]CredentialStatus, error) {
+	var statuses []CredentialStatus
+	if err := vc.UnmarshalCredentialStatus(&statuses); err != nil {
+		return nil, err
+	}
+	return statuses, nil
 }
 
 // Proofs returns the basic proofs for this credential. For specific proof contents, UnmarshalProofValue must be used.
@@ -206,7 +246,7 @@ func (vc VerifiableCredential) MarshalJSON() ([]byte, error) {
 	if data, err := json.Marshal(tmp); err != nil {
 		return nil, err
 	} else {
-		return marshal.NormalizeDocument(data, pluralContext, marshal.Unplural(typeKey), marshal.Unplural(credentialSubjectKey), marshal.Unplural(proofKey))
+		return marshal.NormalizeDocument(data, pluralContext, marshal.Unplural(typeKey), marshal.Unplural(credentialSubjectKey), marshal.Unplural(credentialStatusKey), marshal.Unplural(proofKey))
 	}
 }
 
@@ -229,30 +269,25 @@ func (vc *VerifiableCredential) UnmarshalJSON(b []byte) error {
 // UnmarshalProofValue unmarshalls the proof to the given proof type. Always pass a slice as target since there could be multiple proofs.
 // Each proof will result in a value, where null values may exist when the proof doesn't have the json member.
 func (vc VerifiableCredential) UnmarshalProofValue(target interface{}) error {
-	if asJSON, err := json.Marshal(vc.Proof); err != nil {
-		return err
-	} else {
-		return json.Unmarshal(asJSON, target)
-	}
+	return unmarshalAnySliceToTarget(vc.Proof, target)
 }
 
 // UnmarshalCredentialSubject unmarshalls the credentialSubject to the given credentialSubject type. Always pass a slice as target.
 func (vc VerifiableCredential) UnmarshalCredentialSubject(target interface{}) error {
-	if asJSON, err := json.Marshal(vc.CredentialSubject); err != nil {
+	return unmarshalAnySliceToTarget(vc.CredentialSubject, target)
+}
+
+// UnmarshalCredentialStatus unmarshalls the credentialStatus field to the provided target. Always pass a slice as target.
+func (vc VerifiableCredential) UnmarshalCredentialStatus(target any) error {
+	return unmarshalAnySliceToTarget(vc.CredentialStatus, target)
+}
+
+func unmarshalAnySliceToTarget(s []any, target any) error {
+	if asJSON, err := json.Marshal(s); err != nil {
 		return err
 	} else {
 		return json.Unmarshal(asJSON, target)
 	}
-}
-
-// UnmarshalCredentialStatus unmarshalls the credentialStatus field to the provided target.
-func (vc VerifiableCredential) UnmarshalCredentialStatus(target any) error {
-	type VC struct {
-		Target any `json:"credentialStatus"`
-	}
-
-	cs := VC{Target: target}
-	return json.Unmarshal([]byte(vc.Raw()), &cs)
 }
 
 // SubjectDID returns the credential subject's ID as DID (credentialSubject.id).

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -138,6 +138,32 @@ func TestVerifiableCredential_UnmarshalCredentialSubject(t *testing.T) {
 	})
 }
 
+func TestVerifiableCredential_UnmarshalCredentialStatus(t *testing.T) {
+	// custom status that contains more fields than CredentialStatus
+	type CustomCredentialStatus struct {
+		Id          string `json:"id,omitempty"`
+		Type        string `json:"type,omitempty"`
+		CustomField string `json:"customField,omitempty"`
+	}
+	expectedJSON := `
+	{ "credentialStatus": {
+		"type": "CustomType",
+		"customField": "not empty"
+	  }
+	}`
+	t.Run("ok", func(t *testing.T) {
+		input := VerifiableCredential{}
+		json.Unmarshal([]byte(expectedJSON), &input)
+		var target CustomCredentialStatus
+
+		err := input.UnmarshalCredentialStatus(&target)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "CustomType", target.Type)
+		assert.Equal(t, "not empty", target.CustomField)
+	})
+}
+
 func TestCredentialStatus(t *testing.T) {
 	t.Run("can unmarshal JWT VC Presentation Profile JWT-VC example", func(t *testing.T) {
 		// CredentialStatus example taken from https://identity.foundation/jwt-vc-presentation-profile/#vc-jwt


### PR DESCRIPTION
Needed to introduce StatusList2021 ~I can't find in the spec if `credentialStatus` can be an array or not. All examples are objects.~ CredentialStatus can be an array or an object so applied similar logic as the other plural fields.

Marshaling of the `credentialStatus` is slightly different from the `credentialSubject` and `proof` fields since its format is not necessarily defined by the credential type. A credential type could require using one of several CredentialStatus mechanisms.