### PR TITLE
Don't compact arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,11 @@ Use `ParseVerifiableCredential(raw string)` and `ParseVerifiablePresentation(raw
 go get github.com/nuts-foundation/go-did
 ```
 
+## Testing
+
+```shell
+go test ./... -tags=jwx_es256k
+```
+
 ## State of the library
 We keep the API stable, breaking changes will only be introduced in new major versions.

--- a/did/document.go
+++ b/did/document.go
@@ -210,16 +210,6 @@ func (d *Document) AddCapabilityDelegation(v *VerificationMethod) {
 	d.CapabilityDelegation.Add(v)
 }
 
-func (d Document) MarshalJSON() ([]byte, error) {
-	type alias Document
-	tmp := alias(d)
-	if data, err := json.Marshal(tmp); err != nil {
-		return nil, err
-	} else {
-		return marshal.NormalizeDocument(data, marshal.Unplural(contextKey), marshal.Unplural(controllerKey))
-	}
-}
-
 func (d *Document) UnmarshalJSON(b []byte) error {
 	document, err := ParseDocument(string(b))
 	if err != nil {
@@ -275,18 +265,8 @@ type Service struct {
 	ServiceEndpoint interface{} `json:"serviceEndpoint,omitempty"`
 }
 
-func (s Service) MarshalJSON() ([]byte, error) {
-	type alias Service
-	tmp := alias(s)
-	if data, err := json.Marshal(tmp); err != nil {
-		return nil, err
-	} else {
-		return marshal.NormalizeDocument(data, marshal.Unplural(serviceEndpointKey))
-	}
-}
-
 func (s *Service) UnmarshalJSON(data []byte) error {
-	normalizedData, err := marshal.NormalizeDocument(data, pluralContext, marshal.PluralValueOrMap(serviceEndpointKey))
+	normalizedData, err := marshal.NormalizeDocument(data, pluralContext)
 	if err != nil {
 		return err
 	}

--- a/did/document.go
+++ b/did/document.go
@@ -265,21 +265,7 @@ type Service struct {
 	ServiceEndpoint interface{} `json:"serviceEndpoint,omitempty"`
 }
 
-func (s *Service) UnmarshalJSON(data []byte) error {
-	normalizedData, err := marshal.NormalizeDocument(data, pluralContext)
-	if err != nil {
-		return err
-	}
-	type alias Service
-	var result alias
-	if err := json.Unmarshal(normalizedData, &result); err != nil {
-		return err
-	}
-	*s = (Service)(result)
-	return nil
-}
-
-// Unmarshal unmarshalls the service endpoint into a domain-specific type.
+// UnmarshalServiceEndpoint unmarshalls the service endpoint into a domain-specific type.
 func (s Service) UnmarshalServiceEndpoint(target interface{}) error {
 	var valueToMarshal interface{}
 	if asSlice, ok := s.ServiceEndpoint.([]interface{}); ok && len(asSlice) == 1 {

--- a/did/json.go
+++ b/did/json.go
@@ -12,6 +12,5 @@ const keyAgreementKey = "keyAgreement"
 const capabilityInvocationKey = "capabilityInvocation"
 const capabilityDelegationKey = "capabilityDelegation"
 const verificationMethodKey = "verificationMethod"
-const serviceEndpointKey = "serviceEndpoint"
 
 var pluralContext = marshal.Plural(contextKey)

--- a/did/test/did1-expected.json
+++ b/did/test/did1-expected.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://www.w3.org/ns/did/v1",
+  "@context": ["https://www.w3.org/ns/did/v1"],
   "id": "did:nuts:04cf1e20-378a-4e38-ab1b-401a5018c9ff",
   "controller": [
     "did:nuts:04cf1e20-378a-4e38-ab1b-401a5018c9ff",

--- a/internal/marshal/marshal.go
+++ b/internal/marshal/marshal.go
@@ -46,16 +46,6 @@ func Plural(key string) Normalizer {
 	}
 }
 
-// Unplural returns a Normalizer that converts arrays with a single value into a singular value. It is the opposite
-// of the Plural normalizer.
-func Unplural(key string) Normalizer {
-	return func(m map[string]interface{}) {
-		if arr, _ := m[key].([]interface{}); len(arr) == 1 {
-			m[key] = arr[0]
-		}
-	}
-}
-
 // PluralValueOrMap returns a Normalizer that behaves like Plural but leaves maps as simply a map. In other words,
 // it only turns singular values into an array, except maps.
 func PluralValueOrMap(key string) Normalizer {

--- a/vc/vc.go
+++ b/vc/vc.go
@@ -278,11 +278,7 @@ func (vc VerifiableCredential) MarshalJSON() ([]byte, error) {
 	// Must be a JSON-LD credential
 	type alias VerifiableCredential
 	tmp := alias(vc)
-	if data, err := json.Marshal(tmp); err != nil {
-		return nil, err
-	} else {
-		return marshal.NormalizeDocument(data, pluralContext, marshal.Unplural(typeKey), marshal.Unplural(credentialSubjectKey), marshal.Unplural(credentialStatusKey), marshal.Unplural(proofKey))
-	}
+	return json.Marshal(tmp)
 }
 
 func (vc *VerifiableCredential) UnmarshalJSON(b []byte) error {

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -62,9 +62,10 @@ func TestVerifiableCredential_JSONMarshalling(t *testing.T) {
 
 		t.Run("marshal empty VC", func(t *testing.T) {
 			input := VerifiableCredential{}
-			marshalled, err := json.Marshal(input)
+			actual, err := json.Marshal(input)
 			require.NoError(t, err)
-			assert.Equal(t, "{\"@context\":null,\"credentialSubject\":null,\"issuer\":\"\",\"proof\":null,\"type\":null}", string(marshalled))
+			const expected = "{\"@context\":null,\"credentialSubject\":null,\"issuer\":\"\",\"proof\":null,\"type\":null}"
+			assert.JSONEq(t, expected, string(actual))
 		})
 	})
 	t.Run("JWT", func(t *testing.T) {

--- a/vc/vp.go
+++ b/vc/vp.go
@@ -166,11 +166,7 @@ func (vp VerifiablePresentation) MarshalJSON() ([]byte, error) {
 	}
 	type alias VerifiablePresentation
 	tmp := alias(vp)
-	if data, err := json.Marshal(tmp); err != nil {
-		return nil, err
-	} else {
-		return marshal.NormalizeDocument(data, pluralContext, marshal.Unplural(typeKey), marshal.Unplural(verifiableCredentialKey), marshal.Unplural(proofKey))
-	}
+	return json.Marshal(tmp)
 }
 
 func (vp *VerifiablePresentation) UnmarshalJSON(b []byte) error {

--- a/vc/vp_test.go
+++ b/vc/vp_test.go
@@ -65,36 +65,8 @@ func TestVerifiablePresentation_MarshalJSON(t *testing.T) {
 			if !assert.NoError(t, err) {
 				return
 			}
-			assert.Contains(t, string(bytes), "\"proof\":{")
-			assert.Contains(t, string(bytes), "\"verifiableCredential\":{")
-		})
-		t.Run("ok - multiple credential and proof", func(t *testing.T) {
-			input := VerifiablePresentation{
-				VerifiableCredential: []VerifiableCredential{
-					{
-						Type: []ssi.URI{VerifiableCredentialTypeV1URI()},
-					},
-					{
-						Type: []ssi.URI{VerifiableCredentialTypeV1URI()},
-					},
-				},
-				Proof: []interface{}{
-					JSONWebSignature2020Proof{
-						Jws: "",
-					},
-					JSONWebSignature2020Proof{
-						Jws: "",
-					},
-				},
-			}
-
-			bytes, err := json.Marshal(input)
-
-			if !assert.NoError(t, err) {
-				return
-			}
-			assert.Contains(t, string(bytes), "\"proof\":[")
-			assert.Contains(t, string(bytes), "\"verifiableCredential\":[")
+			assert.Contains(t, string(bytes), "\"proof\":[{")
+			assert.Contains(t, string(bytes), "\"verifiableCredential\":[{")
 		})
 	})
 


### PR DESCRIPTION
This makes it hard to predict what the marshalled JSON object will look like, meaning things like creating presentation submissions will be harder. E.g., input descriptor mapping path can be indexed or not, depending on the number of VCs in the VP.

We also incorrectly applied the principal to serviceEndpoint, fixed that as well.

We should still support parsing compacted arrays, of course.