### PR TITLE
Do not double-escape when converting a DID to URI

### DIFF
--- a/did/did.go
+++ b/did/did.go
@@ -87,7 +87,7 @@ func (d DID) URI() ssi.URI {
 	return ssi.URI{
 		URL: url.URL{
 			Scheme: "did",
-			Opaque: fmt.Sprintf("%s:%s", d.Method, url.PathEscape(d.ID)),
+			Opaque: fmt.Sprintf("%s:%s", d.Method, d.ID),
 		},
 	}
 }

--- a/did/did_test.go
+++ b/did/did_test.go
@@ -134,15 +134,20 @@ func TestDID_Empty(t *testing.T) {
 }
 
 func TestDID_URI(t *testing.T) {
-	id, err := ParseDID("did:nuts:123")
-
-	if !assert.NoError(t, err) {
-		return
+	testCases := []string{
+		"did:nuts:123",
+		"did:web:example.com",
+		"did:web:example.com:123",
+		"did:web:example.com%3A:8443:123",
 	}
-
-	uri := id.URI()
-
-	assert.Equal(t, id.String(), uri.String())
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			id, err := ParseDID(tc)
+			require.NoError(t, err)
+			uri := id.URI()
+			assert.Equal(t, tc, uri.String())
+		})
+	}
 }
 
 func TestError(t *testing.T) {


### PR DESCRIPTION
Found when using a `did:web` with port