### PR TITLE
support erc1056 for did document

### DIFF
--- a/did/did.go
+++ b/did/did.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/nuts-foundation/go-did"
+	"math/big"
 	"net/url"
 	"strings"
+
+	ssi "github.com/nuts-foundation/go-did"
 )
 
 var _ fmt.Stringer = DID{}
@@ -15,16 +17,25 @@ var _ encoding.TextMarshaler = DID{}
 
 // DIDContextV1 contains the JSON-LD context for a DID Document
 const DIDContextV1 = "https://www.w3.org/ns/did/v1"
+const SECP256Recovery = "https://w3id.org/security/suites/secp256k1recovery-2020/v2"
 
 // DIDContextV1URI returns DIDContextV1 as a URI
 func DIDContextV1URI() ssi.URI {
 	return ssi.MustParseURI(DIDContextV1)
 }
 
+// SECP256RecoveryURI returns SECP256Recovery as a URI
+func SECP256RecoveryURI() ssi.URI {
+	return ssi.MustParseURI(SECP256Recovery)
+}
+
 // DID represent a Decentralized Identifier as specified by the DID Core specification (https://www.w3.org/TR/did-core/#identifier).
 type DID struct {
 	// Method is the DID method, e.g. "example".
 	Method string
+	// If the Method is blockchain and the chain id is neccessary use this.
+	// e.g. Method = "ethr", MethodID = "1"
+	MethodID *big.Int
 	// ID is the method-specific ID, in escaped form.
 	ID string
 	// DecodedID is the method-specific ID, in unescaped form.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/ethereum/go-ethereum v1.12.2 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnNEcHYvcCuK6dPZSg=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
+github.com/ethereum/go-ethereum v1.12.2 h1:eGHJ4ij7oyVqUQn48LBz3B7pvQ8sV0wGJiIE6gDq/6Y=
+github.com/ethereum/go-ethereum v1.12.2/go.mod h1:1cRAEV+rp/xX0zraSCBnu9Py3HQ+geRMj3HdR+k0wfI=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/lestrrat-go/blackmagic v1.0.2 h1:Cg2gVSc9h7sz9NOByczrbUvLopQmXrfFx//N+AkAr5k=

--- a/spec-registries.go
+++ b/spec-registries.go
@@ -22,9 +22,12 @@ const ECDSASECP256K1VerificationKey2019 = KeyType("EcdsaSecp256k1VerificationKey
 // https://w3c-ccg.github.io/lds-rsa2018/
 const RSAVerificationKey2018 = KeyType("RsaVerificationKey2018")
 
+// https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/
+// https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md
+const ECDSASECP256K1RecoveryMethod2020 = KeyType("EcdsaSecp256k1RecoveryMethod2020")
+
 type ProofType string
 
 // JsonWebSignature2020 is a Proof type.
 // https://w3c-ccg.github.io/lds-jws2020
 const JsonWebSignature2020 = ProofType("JsonWebSignature2020")
-


### PR DESCRIPTION
I would like to develop a ssi service using your package.

The id document of the ssi service I am developing will support "blockchainAccountId" rather than public key in the "verificationMethod" field based on the example of the link I attached below to support compatibility with the ac-1056 based DIDRegistry convention.

https://github.com/decentralized-identity/ethr-did-resolver/blob/master/doc/did-method-spec.md
https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/

Therefore, I modified it to support the verification method generation function of Ecdsaecp256k1 RecoveryMethod2020 type to support that part of your package.

The code below is a logic that created a document using the code I modified :)

```go
        newDid := "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a"
	didInfo, err := did.ParseDID(newDid)
	if err != nil {
		return nil, err
	}

	// Empty did document:
	doc := &did.Document{
		Context: []interface{}{did.DIDContextV1URI(), did.SECP256RecoveryURI()},
		ID:      *didInfo,
	}

	// Add an assertionMethod
	keyID, _ := did.ParseDIDURL(fmt.Sprintf("%s#key-1", newDid))

	keyID.DID.MethodID = common.Big1
	didInfo.MethodID = common.Big1

	verificationMethod, err := did.NewVerificationMethod(*keyID, ssi.ECDSASECP256K1RecoveryMethod2020, *didInfo, nil)
	if err != nil {
		return nil, err
	}

	// This adds the method to the VerificationMethod list and stores a reference to the assertion list
	doc.AddAssertionMethod(verificationMethod)

	didJson, _ := json.MarshalIndent(doc, "", "  ")
	fmt.Println(string(didJson))
```

result : 

```json
{
  "@context": [
    "https://www.w3.org/ns/did/v1",
    "https://w3id.org/security/suites/secp256k1recovery-2020/v2"
  ],
  "assertionMethod": [
    "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#key-1"
  ],
  "id": "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
  "verificationMethod": [
    {
      "blockchainAccountId": "eip155:1:0xb9c5714089478a327f09197987f16f9e5d936e8a",
      "controller": "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
      "id": "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#key-1",
      "type": "EcdsaSecp256k1RecoveryMethod2020"
    }
  ]
}
```