### PR TITLE
Add omitempty to vc.Proof tag

### DIFF
--- a/vc/vc.go
+++ b/vc/vc.go
@@ -148,7 +148,7 @@ type VerifiableCredential struct {
 	// CredentialSubject holds the actual data for the credential. It must be extracted using the UnmarshalCredentialSubject method and a custom type.
 	CredentialSubject []interface{} `json:"credentialSubject"`
 	// Proof contains the cryptographic proof(s). It must be extracted using the Proofs method or UnmarshalProofValue method for non-generic proof fields.
-	Proof []interface{} `json:"proof"`
+	Proof []interface{} `json:"proof,omitempty"`
 
 	format string
 	raw    string

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -277,6 +277,12 @@ func TestVerifiableCredential_Proofs(t *testing.T) {
 		assert.Len(t, proofs, 2)
 		assert.Equal(t, ssi.JsonWebSignature2020, proofs[0].Type)
 	})
+	t.Run("empty", func(t *testing.T) {
+		bs, err := json.Marshal(VerifiableCredential{})
+		require.NoError(t, err)
+		assert.NotContains(t, string(bs), "proof")
+		assert.Contains(t, string(bs), "type") // sanity check
+	})
 }
 
 func TestVerifiableCredential_IsType(t *testing.T) {

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -64,7 +64,7 @@ func TestVerifiableCredential_JSONMarshalling(t *testing.T) {
 			input := VerifiableCredential{}
 			actual, err := json.Marshal(input)
 			require.NoError(t, err)
-			const expected = "{\"@context\":null,\"credentialSubject\":null,\"issuanceDate\":\"0001-01-01T00:00:00Z\",\"issuer\":\"\",\"proof\":null,\"type\":null}"
+			const expected = "{\"@context\":null,\"credentialSubject\":null,\"issuanceDate\":\"0001-01-01T00:00:00Z\",\"issuer\":\"\",\"type\":null}"
 			assert.JSONEq(t, expected, string(actual))
 		})
 	})
@@ -276,12 +276,6 @@ func TestVerifiableCredential_Proofs(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, proofs, 2)
 		assert.Equal(t, ssi.JsonWebSignature2020, proofs[0].Type)
-	})
-	t.Run("empty", func(t *testing.T) {
-		bs, err := json.Marshal(VerifiableCredential{})
-		require.NoError(t, err)
-		assert.NotContains(t, string(bs), "proof")
-		assert.Contains(t, string(bs), "type") // sanity check
 	})
 }
 


### PR DESCRIPTION
to prevent `"proof": null` in [holder claims](https://www.w3.org/TR/vc-data-model-2.0/#presentations-including-holder-claims)