### PR TITLE
Add CreateCredentialOption with WithCredentialSubjectAsObject

### DIFF
--- a/vc/vc.go
+++ b/vc/vc.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/nuts-foundation/go-did/did"
-	"strings"
-	"time"
 
 	ssi "github.com/nuts-foundation/go-did"
 
@@ -378,10 +379,29 @@ func (vc VerifiableCredential) ContainsContext(context ssi.URI) bool {
 
 type JWTSigner func(ctx context.Context, claims map[string]interface{}, headers map[string]interface{}) (string, error)
 
+// CreateCredentialOption is a functional option for CreateJWTVerifiableCredential. It can mutate the JWT claims
+// before signing, or return an error to abort creation.
+type CreateCredentialOption func(claims map[string]interface{}) error
+
+// WithCredentialSubjectAsObject makes CreateJWTVerifiableCredential encode credentialSubject as a single JSON object
+// (rather than an array) in the JWT 'vc' claim. Returns an error if the template does not contain exactly one
+// credentialSubject.
+func WithCredentialSubjectAsObject() CreateCredentialOption {
+	return func(claims map[string]interface{}) error {
+		vcMap := claims["vc"].(map[string]interface{})
+		credentialSubject := vcMap["credentialSubject"].([]map[string]any)
+		if len(credentialSubject) != 1 {
+			return fmt.Errorf("WithCredentialSubjectAsObject requires exactly 1 credentialSubject, got %d", len(credentialSubject))
+		}
+		vcMap["credentialSubject"] = credentialSubject[0]
+		return nil
+	}
+}
+
 // CreateJWTVerifiableCredential creates a JWT Verifiable Credential from the given credential template.
 // For signing the actual JWT it calls the given signer, which must return the created JWT in string format.
 // Note: the signer is responsible for adding the right key claims (e.g. `kid`).
-func CreateJWTVerifiableCredential(ctx context.Context, template VerifiableCredential, signer JWTSigner) (*VerifiableCredential, error) {
+func CreateJWTVerifiableCredential(ctx context.Context, template VerifiableCredential, signer JWTSigner, options ...CreateCredentialOption) (*VerifiableCredential, error) {
 	subjectDID, err := template.SubjectDID()
 	if err != nil {
 		return nil, err
@@ -408,6 +428,11 @@ func CreateJWTVerifiableCredential(ctx context.Context, template VerifiableCrede
 	}
 	if template.CredentialStatus != nil {
 		vcMap["credentialStatus"] = template.CredentialStatus
+	}
+	for _, opt := range options {
+		if err := opt(claims); err != nil {
+			return nil, err
+		}
 	}
 	token, err := signer(ctx, claims, headers)
 	if err != nil {

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -469,6 +469,29 @@ func TestCreateJWTVerifiableCredential(t *testing.T) {
 		assert.Nil(t, claims[jwt.ExpirationKey])
 		assert.Nil(t, claims[jwt.JwtIDKey])
 	})
+	t.Run("WithCredentialSubjectAsObject", func(t *testing.T) {
+		t.Run("single credentialSubject", func(t *testing.T) {
+			var claims map[string]interface{}
+			_, err := CreateJWTVerifiableCredential(ctx, template, func(_ context.Context, c map[string]interface{}, _ map[string]interface{}) (string, error) {
+				claims = c
+				return jwtCredential, nil
+			}, WithCredentialSubjectAsObject())
+			assert.NoError(t, err)
+			vcMap := claims["vc"].(map[string]interface{})
+			assert.Equal(t, template.CredentialSubject[0], vcMap["credentialSubject"])
+		})
+		t.Run("multiple credentialSubjects returns error", func(t *testing.T) {
+			multiTemplate := template
+			multiTemplate.CredentialSubject = []map[string]any{
+				{"id": subjectDID.String()},
+				{"id": subjectDID.String()},
+			}
+			_, err := CreateJWTVerifiableCredential(ctx, multiTemplate, func(_ context.Context, _ map[string]interface{}, _ map[string]interface{}) (string, error) {
+				return jwtCredential, nil
+			}, WithCredentialSubjectAsObject())
+			assert.EqualError(t, err, "WithCredentialSubjectAsObject requires exactly 1 credentialSubject, got 2")
+		})
+	})
 }
 func TestVerifiableCredential_ValidAt(t *testing.T) {
 	low := time.Now()


### PR DESCRIPTION
## Summary
- Add varargs `...CreateCredentialOption` parameter to `CreateJWTVerifiableCredential`.
- Add `WithCredentialSubjectAsObject()` option that encodes `credentialSubject` as a single JSON object (rather than an array) in the JWT `vc` claim.
- The option returns an error when the template does not contain exactly one `credentialSubject`.

## Test plan
- [x] `go test -tags=jwx_es256k ./...`
- [x] New subtests cover single-subject success and multi-subject error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)