### PR TITLE
Validate JWT 'sub' matches credentialSubject.id

### DIFF
--- a/vc/vc.go
+++ b/vc/vc.go
@@ -93,8 +93,14 @@ func parseJWTCredential(raw string) (*VerifiableCredential, error) {
 		result.IssuanceDate = token.NotBefore()
 	}
 	// parse sub
+	// Per https://www.w3.org/TR/2022/REC-vc-data-model-20220303/#jwt-decoding the JWT 'sub' claim maps to
+	// credentialSubject.id. If both are present they must be equal; otherwise silently overwriting would mask
+	// issuer bugs and produce misleading downstream errors.
 	if token.Subject() != "" {
 		for _, credentialSubject := range result.CredentialSubject {
+			if existing, ok := credentialSubject["id"].(string); ok && existing != "" && existing != token.Subject() {
+				return nil, fmt.Errorf("JWT 'sub' claim (%s) does not match credentialSubject.id (%s)", token.Subject(), existing)
+			}
 			credentialSubject["id"] = token.Subject()
 		}
 	}

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -119,6 +119,44 @@ func TestParseVerifiableCredential(t *testing.T) {
 		assert.Nil(t, credential.ExpirationDate)
 		assert.Empty(t, credential.IssuanceDate)
 	})
+	t.Run("JWT copies `sub` into credentialSubject.id when absent", func(t *testing.T) {
+		token := jwt.New()
+		require.NoError(t, token.Set(jwt.SubjectKey, "did:example:123"))
+		require.NoError(t, token.Set("vc", map[string]interface{}{
+			"credentialSubject": map[string]interface{}{"name": "Alice"},
+		}))
+		keyPair, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		tokenBytes, err := jwt.Sign(token, jwt.WithKey(jwa.ES256, keyPair))
+		require.NoError(t, err)
+		credential, err := ParseVerifiableCredential(string(tokenBytes))
+		require.NoError(t, err)
+		assert.Equal(t, "did:example:123", credential.CredentialSubject[0]["id"])
+	})
+	t.Run("JWT accepts matching `sub` and credentialSubject.id", func(t *testing.T) {
+		token := jwt.New()
+		require.NoError(t, token.Set(jwt.SubjectKey, "did:example:123"))
+		require.NoError(t, token.Set("vc", map[string]interface{}{
+			"credentialSubject": map[string]interface{}{"id": "did:example:123", "name": "Alice"},
+		}))
+		keyPair, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		tokenBytes, err := jwt.Sign(token, jwt.WithKey(jwa.ES256, keyPair))
+		require.NoError(t, err)
+		credential, err := ParseVerifiableCredential(string(tokenBytes))
+		require.NoError(t, err)
+		assert.Equal(t, "did:example:123", credential.CredentialSubject[0]["id"])
+	})
+	t.Run("JWT rejects mismatched `sub` and credentialSubject.id", func(t *testing.T) {
+		token := jwt.New()
+		require.NoError(t, token.Set(jwt.SubjectKey, "did:example:123"))
+		require.NoError(t, token.Set("vc", map[string]interface{}{
+			"credentialSubject": map[string]interface{}{"id": "did:example:456", "name": "Alice"},
+		}))
+		keyPair, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		tokenBytes, err := jwt.Sign(token, jwt.WithKey(jwa.ES256, keyPair))
+		require.NoError(t, err)
+		_, err = ParseVerifiableCredential(string(tokenBytes))
+		assert.EqualError(t, err, "JWT 'sub' claim (did:example:123) does not match credentialSubject.id (did:example:456)")
+	})
 }
 
 func TestVerifiableCredential_UnmarshalCredentialSubject(t *testing.T) {


### PR DESCRIPTION
## Summary
- Error when a JWT-VC carries both `sub` and `credentialSubject.id` and they disagree, instead of silently letting `sub` overwrite.
- Copying `sub` into an absent `credentialSubject.id` is unchanged.

Fixes #126.

## Why
Per [W3C VC-DATA-MODEL JWT decoding](https://www.w3.org/TR/2022/REC-vc-data-model-20220303/#jwt-decoding) these two fields encode the same value. The old behavior hides issuer bugs and surfaces as very confusing downstream errors — e.g. a VP bundling three VCs where one VC's own JWT `sub` (`did:x509:...`) disagreed with its `credentialSubject.id` (`did:web:...`). After the silent overwrite, `ResolveSubjectDID` in `nuts-node` reports "not all VCs have the same credentialSubject.id", pointing the operator at the wrong layer — the real bug is *within* one VC.

## Test plan
- [x] `go test ./vc/...` passes
- [x] New subtests cover: copy-on-absent (unchanged behavior), matching values, and mismatch → error
- [x] Existing `TestVerifiableCredential_JSONMarshalling/JWT` still passes (fixture has `sub` but no inner `credentialSubject.id`, so copy path is exercised)

Note: pre-existing `Test_Document/ECDSASECP256K1VerificationKey2019` failure on master is unrelated (secp256k1 curve registration in jwx v2.1+). Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)