### PR TITLE
Set iat claim on JWT VP and JWT VC from IssuedAt

### DIFF
--- a/vc/vc.go
+++ b/vc/vc.go
@@ -416,6 +416,7 @@ func CreateJWTVerifiableCredential(ctx context.Context, template VerifiableCrede
 	}
 	claims := map[string]interface{}{
 		jwt.NotBeforeKey: template.IssuanceDate,
+		jwt.IssuedAtKey:  template.IssuanceDate,
 		jwt.IssuerKey:    template.Issuer.String(),
 		jwt.SubjectKey:   subjectDID.String(),
 		"vc":             vcMap,

--- a/vc/vc.go
+++ b/vc/vc.go
@@ -401,6 +401,7 @@ func WithCredentialSubjectAsObject() CreateCredentialOption {
 // CreateJWTVerifiableCredential creates a JWT Verifiable Credential from the given credential template.
 // For signing the actual JWT it calls the given signer, which must return the created JWT in string format.
 // Note: the signer is responsible for adding the right key claims (e.g. `kid`).
+// If template.IssuanceDate is the zero value, it defaults to the current time (mapped to both 'nbf' and 'iat' claims).
 func CreateJWTVerifiableCredential(ctx context.Context, template VerifiableCredential, signer JWTSigner, options ...CreateCredentialOption) (*VerifiableCredential, error) {
 	subjectDID, err := template.SubjectDID()
 	if err != nil {
@@ -414,9 +415,13 @@ func CreateJWTVerifiableCredential(ctx context.Context, template VerifiableCrede
 		"type":              template.Type,
 		"credentialSubject": template.CredentialSubject,
 	}
+	issuanceDate := template.IssuanceDate
+	if issuanceDate.IsZero() {
+		issuanceDate = time.Now()
+	}
 	claims := map[string]interface{}{
-		jwt.NotBeforeKey: template.IssuanceDate,
-		jwt.IssuedAtKey:  template.IssuanceDate,
+		jwt.NotBeforeKey: issuanceDate,
+		jwt.IssuedAtKey:  issuanceDate,
 		jwt.IssuerKey:    template.Issuer.String(),
 		jwt.SubjectKey:   subjectDID.String(),
 		"vc":             vcMap,

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -470,6 +470,20 @@ func TestCreateJWTVerifiableCredential(t *testing.T) {
 		assert.Nil(t, claims[jwt.ExpirationKey])
 		assert.Nil(t, claims[jwt.JwtIDKey])
 	})
+	t.Run("IssuanceDate defaults to time.Now() when zero", func(t *testing.T) {
+		zeroIssuanceTemplate := template
+		zeroIssuanceTemplate.IssuanceDate = time.Time{}
+		var claims map[string]interface{}
+		_, err := CreateJWTVerifiableCredential(ctx, zeroIssuanceTemplate, func(_ context.Context, c map[string]interface{}, _ map[string]interface{}) (string, error) {
+			claims = c
+			return jwtCredential, nil
+		})
+		assert.NoError(t, err)
+		nbf, ok := claims[jwt.NotBeforeKey].(time.Time)
+		assert.True(t, ok)
+		assert.False(t, nbf.IsZero())
+		assert.Equal(t, nbf, claims[jwt.IssuedAtKey])
+	})
 	t.Run("WithCredentialSubjectAsObject", func(t *testing.T) {
 		t.Run("single credentialSubject", func(t *testing.T) {
 			var claims map[string]interface{}

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -447,6 +447,7 @@ func TestCreateJWTVerifiableCredential(t *testing.T) {
 		assert.Equal(t, subjectDID.String(), claims[jwt.SubjectKey])
 		assert.Equal(t, template.ID.String(), claims[jwt.JwtIDKey])
 		assert.Equal(t, issuanceDate, claims[jwt.NotBeforeKey])
+		assert.Equal(t, issuanceDate, claims[jwt.IssuedAtKey])
 		assert.Equal(t, expirationDate, claims[jwt.ExpirationKey])
 		assert.Equal(t, map[string]interface{}{
 			"credentialSubject": template.CredentialSubject,

--- a/vc/vp.go
+++ b/vc/vp.go
@@ -239,7 +239,8 @@ type PresentationOptions struct {
 	Nonce *string
 	// Audience specifies the intended audience (maps to 'aud' claim in JWT).
 	Audience *string
-	// IssuedAt specifies when the presentation was issued (maps to 'nbf' claim in JWT).
+	// IssuedAt specifies when the presentation was issued (maps to 'nbf' and 'iat' claims in JWT).
+	// Defaults to the current time when nil.
 	IssuedAt *time.Time
 	// ExpiresAt specifies when the presentation expires (maps to 'exp' claim in JWT).
 	// If nil, no expiration claim is added to the JWT.
@@ -287,11 +288,12 @@ func CreateJWTVerifiablePresentation(ctx context.Context, presenter ssi.URI, cre
 	if options.Audience != nil {
 		claims[jwt.AudienceKey] = *options.Audience
 	}
-	if options.IssuedAt == nil {
-		claims[jwt.NotBeforeKey] = time.Now().Unix()
-	} else {
-		claims[jwt.NotBeforeKey] = int(options.IssuedAt.Unix())
+	issuedAt := time.Now()
+	if options.IssuedAt != nil {
+		issuedAt = *options.IssuedAt
 	}
+	claims[jwt.NotBeforeKey] = int(issuedAt.Unix())
+	claims[jwt.IssuedAtKey] = int(issuedAt.Unix())
 
 	token, err := signer(ctx, claims, headers)
 	if err != nil {

--- a/vc/vp_test.go
+++ b/vc/vp_test.go
@@ -308,6 +308,7 @@ func TestCreateJWTVerifiablePresentation(t *testing.T) {
 		assert.Equal(t, nonce, token.PrivateClaims()["nonce"])
 		assert.Equal(t, []string{audience}, token.Audience())
 		assert.Equal(t, nbf.Unix(), token.NotBefore().Unix())
+		assert.Equal(t, nbf.Unix(), token.IssuedAt().Unix())
 		assert.Equal(t, exp.Unix(), token.Expiration().Unix())
 
 		// Verify VP structure
@@ -336,8 +337,10 @@ func TestCreateJWTVerifiablePresentation(t *testing.T) {
 		assert.NotEmpty(t, token.JwtID())
 		assert.Nil(t, token.PrivateClaims()["nonce"])
 		assert.Empty(t, token.Audience())
-		assert.NotZero(t, token.NotBefore()) // auto-set to time.Now() when IssuedAt is nil
-		assert.Zero(t, token.Expiration())   // exp not set when ExpiresAt is nil
+		assert.NotZero(t, token.NotBefore())             // auto-set to time.Now() when IssuedAt is nil
+		assert.NotZero(t, token.IssuedAt())              // auto-set to time.Now() when IssuedAt is nil
+		assert.Equal(t, token.NotBefore(), token.IssuedAt())
+		assert.Zero(t, token.Expiration()) // exp not set when ExpiresAt is nil
 
 		// Verify VP structure
 		assert.Nil(t, vp.Holder) // holder is optional


### PR DESCRIPTION
## Summary
- `CreateJWTVerifiablePresentation` already maps `IssuedAt → nbf`. Also map it to the standard JWT `iat` claim, defaulting to `time.Now()` when `IssuedAt` is nil (same fallback as `nbf`).
- Mirror the same change on `CreateJWTVerifiableCredential`: `IssuanceDate` is now also mapped to the `iat` claim alongside `nbf`. When `IssuanceDate` is the zero value, both claims default to `time.Now()` instead of emitting a zero timestamp.
- Updates the `IssuedAt` doc comment to reflect both mappings and the default.

## Why
`iat` is the conventional JWT-standard claim for issuance time. Without it being set by the library, every caller has to inject it via `AdditionalProofProperties`. Setting it here removes that boilerplate from downstream code.

## Test plan
- [x] `go test ./vc/...` — extended existing tests to assert `iat` is set and equals `nbf` for both VPs and VCs, and that VC creation defaults to `time.Now()` when `IssuanceDate` is zero.

Assisted by AI