### PR TITLE
fix(vc): encode VP holder as iss claim in JWT, not vp.holder

### DIFF
--- a/vc/vp.go
+++ b/vc/vp.go
@@ -263,9 +263,6 @@ func CreateJWTVerifiablePresentation(ctx context.Context, presenter ssi.URI, cre
 		"@context": append([]ssi.URI{VCContextV1URI()}, options.AdditionalContexts...),
 		"type":     append([]ssi.URI{VerifiablePresentationTypeV1URI()}, options.AdditionalTypes...),
 	}
-	if options.Holder != nil {
-		verifiablePresentation["holder"] = options.Holder.String()
-	}
 	if len(credentials) > 0 {
 		verifiablePresentation["verifiableCredential"] = credentials
 	}
@@ -274,6 +271,11 @@ func CreateJWTVerifiablePresentation(ctx context.Context, presenter ssi.URI, cre
 		jwt.SubjectKey: presenter.String(),
 		jwt.JwtIDKey:   id.String(),
 		"vp":           verifiablePresentation,
+	}
+	// Per W3C VC Data Model v1.1 §6.3.1, the holder of a verifiable presentation is
+	// represented by the 'iss' claim, not by a 'holder' member of the 'vp' object.
+	if options.Holder != nil {
+		claims[jwt.IssuerKey] = options.Holder.String()
 	}
 	if options.ExpiresAt != nil {
 		claims[jwt.ExpirationKey] = int(options.ExpiresAt.Unix())

--- a/vc/vp_test.go
+++ b/vc/vp_test.go
@@ -303,6 +303,7 @@ func TestCreateJWTVerifiablePresentation(t *testing.T) {
 
 		// Verify JWT claims
 		token := vp.JWT()
+		assert.Equal(t, holderDID.String(), token.Issuer()) // holder is encoded as 'iss' (VC-DM 1.1 §6.3.1)
 		assert.Equal(t, presenterDID.String(), token.Subject())
 		assert.NotEmpty(t, token.JwtID())
 		assert.Equal(t, nonce, token.PrivateClaims()["nonce"])
@@ -310,6 +311,8 @@ func TestCreateJWTVerifiablePresentation(t *testing.T) {
 		assert.Equal(t, nbf.Unix(), token.NotBefore().Unix())
 		assert.Equal(t, nbf.Unix(), token.IssuedAt().Unix())
 		assert.Equal(t, exp.Unix(), token.Expiration().Unix())
+		// The holder must not be present as a member of the 'vp' object.
+		assert.NotContains(t, token.PrivateClaims()["vp"], "holder")
 
 		// Verify VP structure
 		assert.Equal(t, &holderDID, vp.Holder)
@@ -333,6 +336,7 @@ func TestCreateJWTVerifiablePresentation(t *testing.T) {
 
 		// Verify JWT claims
 		token := vp.JWT()
+		assert.Empty(t, token.Issuer()) // holder is optional, so no 'iss' claim
 		assert.Equal(t, presenterDID.String(), token.Subject())
 		assert.NotEmpty(t, token.JwtID())
 		assert.Nil(t, token.PrivateClaims()["nonce"])


### PR DESCRIPTION
Fixes #147

## Problem

`CreateJWTVerifiablePresentation` did not follow the [W3C VC Data Model v1.1 §6.3.1 (JSON Web Token)](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token) encoding for the presentation holder:

- it never set the `iss` claim, and
- when `options.Holder != nil` it wrote `holder` *inside* the `vp` object (`vp.holder`).

Per §6.3.1 the holder of a verifiable presentation is carried by the top-level `iss` claim. This already matched the parser (`parseJTWPresentation` derives `Holder` from `iss`, using `vp.holder` only as a fallback when `iss` is absent), so creation and parsing disagreed about where the holder lives. Strict external verifiers reject these VP-JWTs: `iss` reported missing, `vp.holder` reported as an unknown claim (confirmed against a real counterparty validator).

## Change

Move the holder from `vp.holder` to `iss` — same guard (`options.Holder != nil`), same value:

```go
claims := map[string]interface{}{
    jwt.SubjectKey: presenter.String(),
    jwt.JwtIDKey:   id.String(),
    "vp":           verifiablePresentation, // no "holder" member
}
if options.Holder != nil {
    claims[jwt.IssuerKey] = options.Holder.String()
}
```

The `Holder` field doc comment already stated it "maps to 'iss' claim in JWT" — the code now honors that.

## Compatibility

- Round-trips identically through `parseJTWPresentation`: `VerifiablePresentation.Holder` is populated from `iss` instead of `vp.holder`, same value. Consumers reading the parsed `Holder` field are unaffected.
- Only the wire format changes, to become spec-compliant.
- JSON-LD path unchanged (`holder` in the body is correct there).
- The `iss`-then-`vp.holder` parser fallback is left in place for tolerance of other implementations.

## Tests

Updated `TestCreateJWTVerifiablePresentation`:
- asserts `iss` == holder and that the `vp` object has no `holder` member (all-properties case),
- asserts no `iss` when `Holder` is unset (mandatory-only case).

`go test ./vc/...` passes.

Assisted by AI