### PR TITLE
fix(vc): avoid infinite recursion in CredentialStatus.UnmarshalJSON on Go 1.27

### DIFF
--- a/vc/vc.go
+++ b/vc/vc.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -200,16 +201,23 @@ type CredentialStatus struct {
 }
 
 func (cs *CredentialStatus) UnmarshalJSON(input []byte) error {
-	type alias *CredentialStatus
-	a := alias(cs)
-	err := json.Unmarshal(input, a)
-	if err != nil {
+	// Unmarshal into a value alias (not a pointer alias): since Go 1.27 encoding/json is backed by
+	// encoding/json/v2, which resolves UnmarshalJSON through a named pointer type and would recurse forever.
+	type alias CredentialStatus
+	var a alias
+	if err := json.Unmarshal(input, &a); err != nil {
+		// report the public type instead of the alias in type errors, so error messages stay stable
+		var typeErr *json.UnmarshalTypeError
+		if errors.As(err, &typeErr) {
+			typeErr.Type = reflect.TypeFor[CredentialStatus]()
+		}
 		return err
 	}
+	*cs = CredentialStatus(a)
 
 	// keep compacted copy of the input
 	buf := new(bytes.Buffer)
-	if err = json.Compact(buf, input); err != nil {
+	if err := json.Compact(buf, input); err != nil {
 		// should never happen, already parsed as valid json
 		return err
 	}

--- a/vc/vc_test.go
+++ b/vc/vc_test.go
@@ -205,6 +205,13 @@ func TestCredentialStatus_UnmarshalJSON(t *testing.T) {
 		assert.Equal(t, "urn:uuid:7facf41c-1dc5-486b-87e6-587d015e76d7?bit-index=10", actual.ID.String())
 		assert.Greater(t, len(actual.raw), 1)
 	})
+	t.Run("type error names CredentialStatus", func(t *testing.T) {
+		var actual CredentialStatus
+
+		err := json.Unmarshal([]byte(`"not an object"`), &actual)
+
+		assert.EqualError(t, err, "json: cannot unmarshal string into Go value of type vc.CredentialStatus")
+	})
 }
 
 func TestCredentialStatus_Raw(t *testing.T) {


### PR DESCRIPTION
Go 1.27 backs `encoding/json` with `encoding/json/v2` by default (https://go.dev/doc/go1.27). The v2-backed decoder resolves `UnmarshalJSON` through the named pointer alias (`type alias *CredentialStatus`) used in `CredentialStatus.UnmarshalJSON`, so the method calls itself until the stack overflows. Any program that unmarshals a credential carrying a `credentialStatus` crashes with `fatal error: stack overflow`. This is what breaks the e2e tests on nuts-foundation/nuts-node#4461 (Docker image bump to golang 1.27).

This PR switches to a value alias and copies the result back, matching the other `UnmarshalJSON` implementations in this module. The existing `TestCredentialStatus_UnmarshalJSON` test reproduces the crash under `GOTOOLCHAIN=go1.27.1 go test ./vc/` before the change and passes after it; the vc package passes under both Go 1.26 and 1.27.1.

A release with this fix is needed before nuts-node can move its Docker image to Go 1.27 (master, V6.2 and V5.4).
